### PR TITLE
ci: add Dependabot auto-merge for patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Auto-approve and merge patch updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          gh pr review "$PR_URL" --approve
+          gh pr merge "$PR_URL" --squash --auto
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Dependabot の semver-patch PR を CI パス後に自動 approve + squash merge するワークフローを追加
- リポジトリ設定の `allow_auto_merge` を有効化済み
- minor / major バンプは引き続き手動レビュー

## Changes
- `.github/workflows/dependabot-auto-merge.yml` を新規追加
- `dependabot/fetch-metadata@v2` で update-type を判定し、patch のみ auto-merge

## Test plan
- [ ] Dependabot が次の月曜に patch PR を出したとき、自動マージされることを確認
- [ ] minor/major バンプの PR は自動マージされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)