### PR TITLE
fix: add max_length constraints to REST API text fields (#39)

### DIFF
--- a/src/insight_blueprint/web.py
+++ b/src/insight_blueprint/web.py
@@ -134,7 +134,7 @@ class AddCommentRequest(BaseModel):
 class AddSourceRequest(BaseModel):
     source_id: str = Field(min_length=1, max_length=_MAX_TITLE_LENGTH)
     name: str = Field(min_length=1, max_length=_MAX_TITLE_LENGTH)
-    type: str
+    type: str = Field(max_length=100)
     description: str = Field(max_length=_MAX_HYPOTHESIS_TEXT_LENGTH)
     connection: dict
     columns: list[dict] | None = None

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -455,6 +455,91 @@ def test_update_design_hypothesis_exceeds_max_length_returns_422(
 
 
 # ---------------------------------------------------------------------------
+# AddSource / UpdateSource max_length boundary tests (Issue #39)
+# ---------------------------------------------------------------------------
+
+
+def test_add_source_name_exceeds_max_length_returns_422(client: TestClient) -> None:
+    """AddSourceRequest.name at 201 chars should be rejected with 422."""
+    _create_design(client)
+    resp = client.post(
+        "/api/catalog/sources",
+        json={
+            "source_id": "ml-src",
+            "name": "N" * 201,
+            "type": "csv",
+            "description": "desc",
+            "connection": {},
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_add_source_source_id_exceeds_max_length_returns_422(
+    client: TestClient,
+) -> None:
+    """AddSourceRequest.source_id at 201 chars should be rejected with 422."""
+    resp = client.post(
+        "/api/catalog/sources",
+        json={
+            "source_id": "S" * 201,
+            "name": "Source",
+            "type": "csv",
+            "description": "desc",
+            "connection": {},
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_add_source_description_exceeds_max_length_returns_422(
+    client: TestClient,
+) -> None:
+    """AddSourceRequest.description at 1001 chars should be rejected with 422."""
+    resp = client.post(
+        "/api/catalog/sources",
+        json={
+            "source_id": "dl-src",
+            "name": "Source",
+            "type": "csv",
+            "description": "D" * 1001,
+            "connection": {},
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_add_source_type_exceeds_max_length_returns_422(client: TestClient) -> None:
+    """AddSourceRequest.type at 101 chars should be rejected with 422."""
+    resp = client.post(
+        "/api/catalog/sources",
+        json={
+            "source_id": "tl-src",
+            "name": "Source",
+            "type": "T" * 101,
+            "description": "desc",
+            "connection": {},
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_add_source_empty_source_id_returns_422(client: TestClient) -> None:
+    """AddSourceRequest.source_id empty string should be rejected (min_length=1)."""
+    resp = client.post(
+        "/api/catalog/sources",
+        json={
+            "source_id": "",
+            "name": "Source",
+            "type": "csv",
+            "description": "desc",
+            "connection": {},
+        },
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
 # Design referenced_knowledge via REST API (2 tests)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- REST API の4つの Pydantic リクエストモデルに `Field(max_length=...)` 制約を追加
- server.py の `_MAX_HYPOTHESIS_TEXT_LENGTH = 1000` と一貫した制限値
- 境界値テスト14件追加 (design系9件 + source系5件)

## Changes
- `CreateDesignRequest`: title (min=1, max=200), hypothesis_statement/background (min=1, max=1000)
- `UpdateDesignRequest`: title (max=200), hypothesis_statement/background (max=1000)
- `AddSourceRequest`: source_id/name (min=1, max=200), description (max=1000), type (max=100)
- `UpdateSourceRequest`: name (max=200), description (max=1000)

## Test plan
- [x] 100 tests in test_web.py passing (+14 new boundary tests)
- [x] ruff check + format pass
- [x] team-review: Critical/High 0, 修正済み (S-07 type field, テスト不足)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)