### PR TITLE
fix: allow model invocation for catalog-register and analysis-design skills (#37)

### DIFF
--- a/src/insight_blueprint/_skills/analysis-design/SKILL.md
+++ b/src/insight_blueprint/_skills/analysis-design/SKILL.md
@@ -27,15 +27,11 @@ insight-blueprint MCP tools. Follows the hypothesis-driven EDA workflow.
 
 ### Step 0: User Confirmation Gate
 
-When this skill is invoked by the model (not by the user typing `/analysis-design`),
-confirm with the user before proceeding:
+Before proceeding, confirm with the user:
 
 - Ask: "分析設計を新規作成しますか？"
 - If the user declines, exit gracefully with a brief message and do not proceed
 - If the user confirms, continue to Step 1
-
-This gate prevents unintended design creation when the model invokes the skill
-autonomously during conversation flow.
 
 ### Step 1: Check Current State
 Call `list_analysis_designs()` to understand existing designs:

--- a/src/insight_blueprint/_skills/catalog-register/SKILL.md
+++ b/src/insight_blueprint/_skills/catalog-register/SKILL.md
@@ -28,15 +28,11 @@ in the insight-blueprint catalog via MCP tools.
 
 ### Step 0: User Confirmation Gate
 
-When this skill is invoked by the model (not by the user typing `/catalog-register`),
-confirm with the user before proceeding:
+Before proceeding, confirm with the user:
 
 - Ask: "このソースをカタログに登録しますか？"
 - If the user declines, exit gracefully with a brief message and do not proceed
 - If the user confirms, continue to Step 1
-
-This gate prevents unintended catalog registration when the model invokes the skill
-autonomously during conversation flow.
 
 ### Step 1: Determine Source Type
 


### PR DESCRIPTION
## Summary
- `catalog-register` と `analysis-design` の2スキルから `disable-model-invocation: true` を削除
- 代わりに Step 0: User Confirmation Gate を追加（無条件確認）
- モデルからのスキル呼び出しが可能になりつつ、意図しない実行を防止

## Changes
- `catalog-register/SKILL.md`: 確認メッセージ "このソースをカタログに登録しますか？"
- `analysis-design/SKILL.md`: 確認メッセージ "分析設計を新規作成しますか？"

## Note
残り5スキル (analysis-framing, analysis-journal, analysis-reflection, analysis-revision, data-lineage) も同様の設定あり。スコープ外のため未変更。

## Test plan
- [x] tests/skills/test_skill_structure.py: 23 passed
- [x] tests/test_skill_integration.py: 7 passed
- [x] team-review: Q-01 修正済み (確認ゲートを無条件化)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)