### PR TITLE
docs: add founding spec documents (SPEC-1 through SPEC-4b)

### DIFF
--- a/.spec-workflow/specs/SPEC-1/design.md
+++ b/.spec-workflow/specs/SPEC-1/design.md
@@ -1,0 +1,354 @@
+# SPEC-1: core-foundation — 設計
+
+> **Spec ID**: SPEC-1
+> **Status**: pending_approval
+> **Created**: 2026-02-18
+> **Source**: DESIGN.md v1.1.0
+
+---
+
+## 概要
+
+SPEC-1 は insight-blueprint のコア基盤を確立する。データサイエンティストが
+`uvx insight-blueprint --project /path` の1コマンドで起動できるゼロインストール MCP サーバーであり、
+CLI エントリポイント・`.insight/` ディレクトリ初期化・Pydantic データモデル・アトミック YAML 永続化・
+3つの MCP ツール（`create_analysis_design`、`get_analysis_design`、`list_analysis_designs`）を実装する。
+これにより Claude Code は手動のファイルシステム操作なしに、仮説駆動型の分析設計書を管理できるようになる。
+
+## ステアリングドキュメントとの整合
+
+### 技術標準（tech.md）
+
+本設計は以下の技術標準に従う:
+
+- **MCP サーバー**: fastmcp>=2.0、stdio トランスポート（Claude Code ローカル統合の標準）
+- **ストレージ**: コメント保持のために ruamel.yaml を使用、アトミック書き込みには `tempfile.mkstemp()` + `os.replace()`
+- **品質ツール**: ruff（lint/format、line-length 88）、ty（型チェック、mypy の代替）、pytest（カバレッジ 80%+ 目標）
+- **開発方法論**: TDD（Red-Green-Refactor）と YAGNI — SPEC-1 が要求する実装のみ行う。WebUI やデーモンスレッドは対象外
+- **プロセスモデル**: `mcp.run()` はメインスレッドをブロックする（MCP プロトコルは stdin/stdout 経由）。uvicorn デーモンスレッドは SPEC-4 のスコープ
+
+### プロジェクト構造（structure.md）
+
+`src/` レイアウト規約と 3 層分離に従う:
+
+- **src/insight_blueprint/** — トップレベルパッケージ（`__init__.py` と `__main__.py`）
+- **3 層アーキテクチャ**: `cli.py` → `server.py` → `core/designs.py` → `storage/`
+- **単方向依存**: CLI → MCP → Core → Storage。逆方向の依存は禁止
+- **SPEC-1 で作成するモジュール**: `cli.py`、`server.py`、`models/design.py`、`models/common.py`、`storage/yaml_store.py`、`storage/project.py`、`core/designs.py`
+- **重要な不変条件**: `mcp.run()` は常に `cli.py` の最後の呼び出し。すべての YAML 書き込みはアトミック。`_service` は MCP ツール呼び出し前に `init_project()` で初期化される
+
+## コード再利用分析
+
+### 活用できる既存コンポーネント
+
+SPEC-1 は最初のスペックであるため、活用できる既存のアプリケーションコードは存在しない。
+以下の外部ライブラリが基盤的な構成要素を提供する:
+
+- **fastmcp**: `@mcp.tool()` デコレータによる MCP ツール登録と stdio トランスポート
+- **Pydantic v2 BaseModel**: `AnalysisDesign` の型安全なデータモデリング、シリアライゼーション、バリデーション
+- **ruamel.yaml**: アナリストのコメントを保持した YAML 読み書き（pyyaml はコメントを削除するため不採用）
+- **click**: `@click.command()` と `@click.option()` による CLI 引数パース
+
+### 統合ポイント
+
+- **Claude Code `.mcp.json`**: `init_project()` は project root の `.mcp.json` に MCP サーバーエントリを登録し、次回起動時に Claude Code が自動検出できるようにする
+- **SPEC-2 以降**: `storage/yaml_store.py` と `storage/project.py` は拡張される。`server.py` は既存ツールを変更せずに `@mcp.tool()` が追加登録される。`core/designs.py` のパターンはカタログ・ルールモジュールに複製される
+
+## アーキテクチャ
+
+### モジュラー設計原則
+
+- **ファイル単一責任**: 各ファイルは1つの関心事のみを担当（`cli.py` = エントリポイント、`server.py` = MCP ツール、`core/designs.py` = ビジネスロジック、`storage/yaml_store.py` = YAML I/O）
+- **コンポーネント分離**: 各層は独立してテスト可能。`core/designs.py` は `server.py` や `cli.py` をインポートせずにユニットテストできる
+- **サービス層分離**: MCP ツール（`server.py`）は `DesignService`（`core/designs.py`）に委譲し、`DesignService` は `yaml_store.py` に委譲する。層をスキップした呼び出しは禁止
+- **ユーティリティのモジュール化**: `models/common.py` は共有ユーティリティ（`now_jst()`）のみを保持する。他のモジュールに混在させない
+
+### コンポーネント図（SPEC-1 スコープ）
+
+```
+Claude Code (AI Client)
+       |
+  stdio (MCP Protocol)
+       |
+  +---------------------------+
+  |  insight-blueprint        |
+  |  (Python Process)         |
+  |                           |
+  |  cli.py (entry point)     |
+  |    ├── init_project()     |
+  |    └── mcp.run() ← BLOCKS |
+  |                           |
+  |  server.py (FastMCP)      |
+  |    ├── create_analysis_design  |
+  |    ├── get_analysis_design     |
+  |    └── list_analysis_designs   |
+  |           ↓               |
+  |  core/designs.py          |
+  |           ↓               |
+  |  storage/yaml_store.py    |
+  |  storage/project.py       |
+  +---------------------------+
+           ↓
+  .insight/
+    ├── config.yaml          (schema_version: 1)
+    ├── catalog/
+    │   ├── sources.yaml
+    │   └── knowledge/
+    ├── designs/*.yaml
+    └── rules/
+        ├── review_rules.yaml
+        └── analysis_rules.yaml
+  .mcp.json  (upserted at project root; machine-specific, gitignore recommended)
+  .claude/skills/analysis-design/  (copied from package on first run only)
+```
+
+### 設計決定: stdio トランスポート
+
+fastmcp の `mcp.run()` は stdio トランスポートを使用する。これが正しい選択である理由:
+- Claude Code の `claude mcp add` はローカル統合においてデフォルトで stdio を想定する
+- ネットワーク設定不要・ポート競合なし
+- `mcp.run()` がメインスレッドをブロックするのは意図的な設計
+
+SPEC-4 でデーモンスレッド上に uvicorn を追加する。SPEC-1 には HTTP サーバーは存在しない。
+
+### 設計決定: テンプレート配布にシンボリックリンクではなくコピーを使用
+
+`shutil.copytree()` を使用して、バンドルされた `_skills/analysis-design/` テンプレートを
+`.claude/skills/analysis-design/` に初回実行時にコピーする。シンボリックリンクを明示的に避ける理由:
+
+- `uvx` はバージョン固有のパス（`~/.cache/uv/.../<version>/`）にパッケージをキャッシュする。シンボリックリンクは新バージョンへのアップグレード時に無通知で破損する
+- Windows ではシンボリックリンクの作成に管理者権限が必要なため、クロスプラットフォーム移植性の問題になる
+- コピー（上書きしない）により、初回実行後にユーザーが行ったカスタマイズが保護される
+
+テンプレートのアップグレードは **SPEC-1 のスコープ外**。将来の `insight-blueprint upgrade-templates` コマンドで対応する（別の GitHub Issue として追跡）。
+
+### 設計決定: `.mcp.json` への `.gitignore` 推奨
+
+`init_project()` は `.mcp.json` の `mcpServers["insight-blueprint"]` キーのみを upsert し、
+他のサーバー登録を保持する。`args` に格納される絶対プロジェクトパスはマシン固有であるため:
+
+- 他の開発者のマシンで動作しないマシン固有パスのコミットを防ぐため、**`.mcp.json` は `.gitignore` に追加すべき**
+- 将来の改善（GitHub Issue として追跡）として、`.mcp.json` を git で共有可能にするために相対パス `"."` の使用を検討するが、SPEC-1 では簡潔さと正確性のために絶対パスを使用する
+
+## コンポーネントとインターフェース
+
+### `cli.py`
+
+- **目的:** CLI エントリポイント — `--project` と `--headless` オプションをパースし、project path の存在を検証し、`init_project()` を呼び出し、`mcp.run()` で MCP サーバーを起動する。`--headless` は SPEC-1 では no-op（SPEC-4 のブラウザ起動抑制用に予約）
+- **インターフェース:** `main(project: str, headless: bool) -> None`（click コマンド、`insight-blueprint` コンソールスクリプトとして登録）
+- **依存関係:** `click`、`storage/project.py:init_project`、`server.py:mcp`
+- **再利用:** なし（依存チェーンの最初のモジュール）
+
+### `server.py`
+
+- **目的:** FastMCP サーバー — 3つの非同期 MCP ツールを登録し、`init_project()` が `mcp.run()` 呼び出し前に初期化するモジュールレベルの `_service` 参照を保持する
+- **インターフェース:** `create_analysis_design(title, hypothesis_statement, hypothesis_background, parent_id?, theme_id: str = "DEFAULT") -> dict`、`get_analysis_design(design_id) -> dict`、`list_analysis_designs(status?) -> dict`（すべて非同期、`@mcp.tool()` デコレータ付き）
+- **依存関係:** `fastmcp.FastMCP`、`core/designs.py:DesignService`
+- **再利用:** なし
+
+### `models/common.py`
+
+- **目的:** 共有タイムゾーンユーティリティ — すべての Pydantic モデルで使用される JST タイムゾーン対応の datetime デフォルト値を提供する `now_jst()` を実装
+- **インターフェース:** `now_jst() -> datetime`
+- **依存関係:** `zoneinfo.ZoneInfo`
+- **再利用:** なし
+
+### `models/design.py`
+
+- **目的:** Pydantic データモデル — `DesignStatus` Enum と、すべての必須フィールドおよび JST タイムゾーンデフォルトを持つ `AnalysisDesign` BaseModel を定義
+- **インターフェース:** `DesignStatus`（5値の str Enum）、`AnalysisDesign`（10フィールドの BaseModel: `theme_id: str = "DEFAULT"` フィールドを含む）
+- **依存関係:** `pydantic.BaseModel`、`pydantic.Field`、`models/common.py:now_jst`
+- **再利用:** なし
+
+### `storage/project.py`
+
+- **目的:** プロジェクト初期化 — アーティファクトごとのべき等初期化。`.insight/` ディレクトリツリー（`designs/`、`catalog/`（`sources.yaml` と `knowledge/`）、`rules/`（`review_rules.yaml` と `analysis_rules.yaml`）、`config.yaml`（`schema_version` 付き））を作成する。不在時のみパッケージから `.claude/skills/analysis-design/` テンプレートをコピー（ユーザーカスタマイズ保護のため上書きしない）。バンドルされた `_skills/analysis-design/SKILL.md` は Claude Code スキル仕様の YAML frontmatter（`name`, `description`, `disable-model-invocation: true`, `argument-hint: "[theme_id]"`）を含み、MCP ツールリファレンス・エラーハンドリング・言語ルールを記載すること。既存サーバーを保持しつつ project root の `.mcp.json` にサーバーエントリを upsert する（アトミック書き込み）。`DesignService` を `server._service` に接続する
+- **インターフェース:** `init_project(project_path: Path) -> None`
+- **依存関係:** `pathlib.Path`、`shutil`、`json`、`core/designs.py:DesignService`、`server._service`
+- **再利用:** なし
+
+### `storage/yaml_store.py`
+
+- **目的:** アトミック YAML I/O — `tempfile.mkstemp()` + `os.replace()` を使用してクラッシュセーフな読み書き操作を提供し、部分書き込みを防止する
+- **インターフェース:** `read_yaml(path: Path) -> dict`、`write_yaml(path: Path, data: dict) -> None`
+- **依存関係:** `ruamel.yaml.YAML`、`tempfile`、`os`
+- **再利用:** なし
+
+### `core/designs.py`
+
+- **目的:** 分析設計 CRUD のビジネスロジック — テーマ別独立連番 ID 生成（FP-H01、TX-H01 等）、作成、取得、ステータスフィルタリングによる一覧取得を管理する
+- **インターフェース:** `DesignService(project_path: Path)` — メソッド: `create_design(title, hypothesis_statement, hypothesis_background, parent_id?, theme_id: str = "DEFAULT") -> AnalysisDesign`、`get_design(design_id) -> AnalysisDesign | None`、`list_designs(status?) -> list[AnalysisDesign]`
+  - `create_design` は theme_id が `[A-Z][A-Z0-9]*` に一致しない場合 `ValueError` を raise する
+- **依存関係:** `models/design.py:AnalysisDesign`、`storage/yaml_store.py:read_yaml, write_yaml`
+- **再利用:** なし
+
+## データモデル
+
+### ファイル: `.insight/designs/{id}_hypothesis.yaml`
+
+```yaml
+id: FP-H01
+theme_id: FP
+title: Foreign population vs crime rate correlation
+hypothesis_statement: No positive correlation exists between...
+hypothesis_background: |
+  ...
+status: draft
+parent_id: null
+metrics: {}
+created_at: "2026-02-18T10:00:00+09:00"
+updated_at: "2026-02-18T10:00:00+09:00"
+```
+
+- ID 生成: `{THEME_ID}-H{N:02d}`（テーマ内の既存 ID の最大 N + 1。削除後も衝突しない）
+- ファイル名: `{THEME_ID}-H{N:02d}_hypothesis.yaml`（例: `FP-H01_hypothesis.yaml`）
+- `theme_id` 省略時は `"DEFAULT"` を使用（例: `DEFAULT-H01`）
+- `theme_id` 許容パターン: `[A-Z][A-Z0-9]*`（英大文字始まり、英大文字・数字のみ）
+- 不正値は `ValueError` を raise する（server.py で error dict に変換）
+
+## エラーハンドリング
+
+### エラーシナリオ
+
+1. **設計が見つからない** — `get_analysis_design("FP-H99")` で FP-H99 が存在しない場合
+   - **ハンドリング:** `DesignService.get_design()` が `None` を返す。`server.py` が `{"error": "Design 'FP-H99' not found"}` に変換する
+   - **ユーザーへの影響:** Claude はエラー dict を受け取り、設計 ID が存在しないことをアナリストに伝えられる
+
+2. **無効な project path** — CLI に `--project /nonexistent` を渡した場合
+   - **ハンドリング:** 初期化より前に、人間が読めるメッセージとともに `click.ClickException` が発生する
+   - **ユーザーへの影響:** エラーメッセージが stderr に出力され、exit code 1 で終了する。部分的な状態は作成されない
+
+3. **YAML 書き込み失敗** — `write_yaml()` 実行中に I/O エラーが発生した場合
+   - **ハンドリング:** `os.replace()` は呼び出されない。`except` ブロックで tempfile がクリーンアップされる。元の YAML は変更されない
+   - **ユーザーへの影響:** `create_analysis_design()` が例外を発生させる。Claude がストレージエラーを報告し、アナリストはリトライできる
+
+4. **サービスが初期化されていない** — `init_project()` より前に MCP ツールが呼び出された場合
+   - **ハンドリング:** `get_service()` が `RuntimeError("Service not initialized. Call init_project() first.")` を発生させる
+   - **ユーザーへの影響:** MCP プロトコルがエラーレスポンスを返す。`cli.py` は常に `mcp.run()` の前に `init_project()` を呼び出すため、テスト/開発シナリオでのみ発生しうる
+
+5. **破損した `.mcp.json`** — project root の `.mcp.json` が有効な JSON としてパースできない場合
+   - **ハンドリング:** `json.JSONDecodeError` を捕捉し、ファイルパスを含む `click.ClickException` として再送出する。ユーザーに JSON を手動修正するか、バックアップを作成してファイルを削除してからリトライするよう案内する
+   - **ユーザーへの影響:** project 初期化が exit code 1 で中断される。元の破損ファイルは変更されない。修復または置換の操作可能なガイダンスをユーザーに提供する
+
+6. **無効な theme_id** — `create_analysis_design()` に `"fp"` や `"FP/X"` などを渡した場合
+   - **ハンドリング:** `DesignService.create_design()` が `ValueError` を raise する。`server.py` が `{"error": "Invalid theme_id 'fp': must match [A-Z][A-Z0-9]*"}` に変換する
+   - **ユーザーへの影響:** Claude がエラー dict を受け取り、theme_id のフォーマットを修正するようアナリストに案内できる
+
+## テスト戦略
+
+### ユニットテスト
+
+テストはモジュール境界ごとに整理される:
+
+| ファイル | カバレッジ対象 |
+|---------|--------------|
+| `tests/test_designs.py` | `core/designs.py` + `models/design.py` |
+| `tests/test_storage.py` | `storage/yaml_store.py` + `storage/project.py` |
+| `tests/test_cli.py` | `cli.py`（click CLI 引数パース） |
+| `tests/test_server.py` | `server.py`（MCP tool 層の dict 変換） |
+
+**test_designs.py のテストケース:**
+- `test_create_design_returns_design_with_generated_id` — ハッピーパス
+- `test_create_design_saves_yaml_file` — ファイルシステム副作用
+- `test_create_design_sequential_ids` — FP-H01、FP-H02、FP-H03 の順序
+- `test_get_design_returns_correct_design` — ラウンドトリップ
+- `test_get_design_returns_none_for_missing_id` — 未発見
+- `test_list_designs_returns_all` — 複数の設計
+- `test_list_designs_filtered_by_status` — ステータスフィルタ
+- `test_create_design_with_theme_id_uses_theme_prefix` — theme_id 付き ID 生成（例: `FP-H01`）
+- `test_create_design_in_different_themes_number_independently` — 異なるテーマ（FP・TX）で H01 が独立して連番される
+- `test_create_design_with_invalid_theme_id_raises_value_error` — "fp"、"FP/X"、"1FP" などが ValueError を raise する
+
+**test_storage.py のテストケース:**
+- `test_write_yaml_creates_file` — 基本的な書き込み
+- `test_write_yaml_is_atomic` — 失敗時のクリーンアップ
+- `test_read_yaml_returns_empty_for_missing_file` — 欠落ファイルの安全な処理
+- `test_init_project_creates_directory_structure` — `.insight/` ツリーのべき等作成
+- `test_init_project_creates_catalog_sources_yaml` — init 後に `catalog/sources.yaml` スタブが存在する
+- `test_init_project_creates_catalog_knowledge_dir` — init 後に `catalog/knowledge/` ディレクトリが存在する
+- `test_init_project_creates_rules_yaml_stubs` — `review_rules.yaml` と `analysis_rules.yaml` の両方が存在する
+- `test_init_project_creates_config_with_schema_version` — `config.yaml` に `schema_version: 1` が含まれる
+- `test_init_project_copies_skills_template_when_absent` — 初回実行時に `.claude/skills/analysis-design/` が作成される
+- `test_init_project_does_not_overwrite_existing_skills` — 既存の `.claude/skills/analysis-design/` は変更されない
+- `test_init_project_copies_skill_has_valid_frontmatter` — コピーされた SKILL.md に `---` 区切りの YAML frontmatter が存在し、`name` と `description` キーを含む
+- `test_init_project_registers_mcp_json_when_absent` — `.mcp.json` が存在しない場合に `mcpServers.insight-blueprint` が作成される
+- `test_init_project_merges_existing_mcp_json` — 他のサーバーエントリを持つ既存の `.mcp.json` は保持され、`insight-blueprint` キーのみ追加/更新される
+- `test_init_project_does_not_modify_if_already_registered` — `insight-blueprint` が既に登録済みの場合、init の再実行で他のキーが変更されたり不必要な書き込みが発生したりしない
+- `test_init_project_partial_recovery` — 部分的な失敗後に init を再実行した場合、既存のものには触れず欠落したアーティファクトのみ作成される
+
+**test_cli.py のテストケース:**
+- `test_cli_default_project_uses_cwd` — `--project` 省略時にカレントディレクトリが使用される（AC-1-2 対応）
+- `test_cli_nonexistent_project_exits_with_error` — 存在しないパスで exit code 1 で終了する（AC-1-3 対応）
+
+**test_server.py のテストケース:**
+- `test_create_analysis_design_returns_dict_with_id_and_status` — `{"id": "FP-H01", "status": "draft", ...}` の dict 形式での返却確認（AC-2-1 対応）
+- `test_get_analysis_design_returns_error_dict_for_missing_id` — 存在しない ID に対してエラー dict を返却（例外でない）（AC-2-3 対応）
+- `test_list_analysis_designs_returns_count_field` — `count` フィールドが存在し結果数と一致する（AC-2-4 対応）
+- `test_get_service_raises_when_not_initialized` — 初期化前の呼び出しで `RuntimeError` が発生する（エラーシナリオ 4 対応）
+- `test_create_analysis_design_returns_error_dict_for_invalid_theme_id` — 不正 theme_id に対してエラー dict が返る（例外でない）（AC-2-6 対応）
+
+**テストインフラ** (`tests/conftest.py`):
+
+```python
+@pytest.fixture
+def tmp_project(tmp_path: Path) -> Path:
+    """Returns a temporary project directory with .insight/ initialized."""
+    from insight_blueprint.storage.project import init_project
+    init_project(tmp_path)
+    return tmp_path
+```
+
+### インテグレーションテスト
+
+- CLI から CRUD までのラウンドトリップ: `init_project()` → `create_analysis_design()` → YAML ファイル作成を確認 → `get_analysis_design()` → データ一致を確認 → `list_analysis_designs()` → 件数とステータスフィルタを確認
+- `tests/test_integration.py` に実装（タスク 1.6 で実装）
+- 実際の `tmp_path` フィクスチャを使用してテストを実行。ストレージ層はモックしない
+
+### E2E テスト
+
+MCP プロトコルの E2E テスト（実際の MCP クライアントを stdio サーバーに接続する）は **SPEC-1 のスコープ外**。
+`test_integration.py` のインテグレーションテストがビジネスロジックスタック全体をエンドツーエンドでカバーする。
+fastmcp stdio テストハーネスが利用可能になった将来のスペックで MCP プロトコルの完全な E2E テストに対応する。
+
+### 受け入れ基準 × テストケース 対応表
+
+requirements.md に定義された全 AC と、それをカバーするテストケースの対応を以下に示す:
+
+| AC | 内容（要約） | 対応テストケース | テストファイル |
+|----|-------------|----------------|--------------|
+| AC-1-1 | `--project /path` → `.insight/` 作成 + stdio 起動 | `test_init_project_creates_directory_structure` | `test_storage.py` |
+| AC-1-2 | `--project` 省略 → cwd 使用 | `test_cli_default_project_uses_cwd` | `test_cli.py` |
+| AC-1-3 | `--project /nonexistent` → exit 1 | `test_cli_nonexistent_project_exits_with_error` | `test_cli.py` |
+| AC-1-4 | 2回実行でデータ破損しない（べき等） | `test_init_project_partial_recovery`、`test_init_project_does_not_modify_if_already_registered` | `test_storage.py` |
+| AC-2-1 | `create_analysis_design()` → dict 返却 + YAML 保存 | `test_create_analysis_design_returns_dict_with_id_and_status`、`test_create_design_saves_yaml_file` | `test_server.py`、`test_designs.py` |
+| AC-2-2 | `get_analysis_design("FP-H01")` → ラウンドトリップ | `test_get_design_returns_correct_design` | `test_designs.py` |
+| AC-2-3 | `get_analysis_design("FP-H99")` → error dict（例外でない） | `test_get_analysis_design_returns_error_dict_for_missing_id` | `test_server.py` |
+| AC-2-4 | `list_analysis_designs(status="draft")` → `count` 一致 | `test_list_analysis_designs_returns_count_field`、`test_list_designs_filtered_by_status` | `test_server.py`、`test_designs.py` |
+| AC-2-5 | YAML 書き込み中クラッシュ → 元ファイル保全 | `test_write_yaml_is_atomic` | `test_storage.py` |
+| AC-2-6 | 不正 theme_id → error dict（例外でない） | `test_create_analysis_design_returns_error_dict_for_invalid_theme_id` | `test_server.py` |
+
+> **注記**: AC-1-1 の stdio 起動部分は MCP プロトコル E2E テストが必要なため SPEC-1 のスコープ外とする。
+> ディレクトリ作成のストレージ側はユニットテストでカバーする。
+
+---
+
+## 依存関係（SPEC-1 のみ）
+
+```toml
+[project]
+dependencies = [
+    "fastmcp>=2.0",
+    "pydantic>=2.10",
+    "ruamel.yaml>=0.18",
+    "click>=8.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=6.0",
+    "ruff>=0.8",
+    "ty>=0.1",
+    "poethepoet>=0.31",
+]
+```

--- a/.spec-workflow/specs/SPEC-1/requirements.md
+++ b/.spec-workflow/specs/SPEC-1/requirements.md
@@ -1,0 +1,185 @@
+# SPEC-1: core-foundation — Requirements
+
+> **Spec ID**: SPEC-1
+> **Feature Name**: core-foundation
+> **Status**: pending_approval
+> **Created**: 2026-02-18
+> **Depends On**: none (first spec)
+
+---
+
+## Introduction
+
+SPEC-1 establishes the core foundation of insight-blueprint — a zero-install MCP server
+that data scientists can launch with a single `uvx insight-blueprint --project /path` command.
+It covers CLI entry point, `.insight/` directory initialization, Pydantic data models,
+atomic YAML persistence, and three MCP tools for managing hypothesis-driven analysis design
+documents. After SPEC-1 is complete, Claude Code can call `create_analysis_design()`,
+`get_analysis_design()`, and `list_analysis_designs()` to persist and retrieve structured
+YAML documents without manual file system access.
+
+## Alignment with Product Vision
+
+This spec directly enables the three core product goals defined in `product.md`:
+
+- **Lightweight analysis design docs**: Provides the `create_analysis_design()` MCP tool
+  and YAML storage layer that Claude Code uses to persist structured hypothesis documents
+  without the heavy overhead of spec-driven development workflows.
+- **Zero-install distribution**: Implements the `uvx insight-blueprint --project /path`
+  entry point and `.mcp.json` registration so data scientists can start an MCP-enabled
+  EDA session without a manual install step.
+- **Spec Roadmap foundation**: All subsequent specs (SPEC-2 through SPEC-5) extend the
+  modules and patterns established here; SPEC-1 is a prerequisite for every later spec.
+
+## Requirements
+
+### Requirement 1: CLI起動とプロジェクト初期化
+
+**User Story:** As a data scientist using Claude Code, I want to run
+`uvx insight-blueprint --project /path/to/analysis` once and have `.insight/` initialized
+and Claude Code ready to call MCP tools immediately, so that I can start my EDA session
+without manual setup.
+
+**FR-1: CLI Entry Point**
+- `uvx insight-blueprint --project <path>` で MCP server を起動する
+- `--project` を省略した場合はカレントディレクトリをデフォルトとする
+- `--headless` flag でブラウザ起動を抑制する（自動化・CI 用途）
+- project path が存在しない場合、意味のあるエラーメッセージを表示して終了する
+
+**FR-2: Project 初期化**
+- 初回実行時に `.insight/` ディレクトリ構造を作成する（idempotent — 複数回実行しても安全）
+- ディレクトリ構造:
+  ```
+  .insight/
+  ├── config.yaml
+  ├── catalog/
+  │   ├── sources.yaml
+  │   └── knowledge/
+  ├── designs/
+  └── rules/
+      ├── review_rules.yaml
+      └── analysis_rules.yaml
+  ```
+- 初回実行時に `.claude/skills/` テンプレートをコピーする（`.claude/skills/analysis-design/` が存在しない場合のみ）
+  - バンドルされたテンプレートは Claude Code スキル仕様に準拠した YAML frontmatter を含むこと:
+    `name`, `description`（Claude の自動検出用トリガーフレーズを含む）、
+    `disable-model-invocation: true`, `argument-hint`
+- `.mcp.json` を project root に登録する（未登録の場合のみ）
+
+#### Acceptance Criteria
+
+1. WHEN `uvx insight-blueprint --project /path` is executed THEN `.insight/` directory is created and MCP server starts in stdio mode
+2. WHEN `--project` is omitted THEN current directory is used as project root
+3. WHEN `--project /nonexistent` is specified THEN an error message is printed and the process exits with code 1
+4. WHEN `uvx insight-blueprint` is run twice on the same project THEN data is not corrupted (idempotent initialization)
+5. WHEN `.claude/skills/analysis-design/SKILL.md` is copied to the project THEN it contains valid YAML frontmatter with `name`, `description`, `disable-model-invocation`, and `argument-hint` fields per Claude Code skill specification
+
+### Requirement 2: 分析設計の管理
+
+**User Story:** As a data scientist, I want Claude to call `create_analysis_design()` with
+my hypothesis details and have a structured YAML file saved to `.insight/designs/`, and
+then retrieve or list those designs via `get_analysis_design()` and `list_analysis_designs()`
+without manually opening the file system, so that I can manage multiple hypotheses efficiently
+during an EDA session.
+
+**FR-3: 分析設計データモデル**
+- `AnalysisDesign` は以下のフィールドを持つ:
+  - `id: str` — 自動生成（例: `FP-H01`, `FP-H02`）
+  - `theme_id: str` — テーマ識別子（例: "FP", "TX"、省略時は "DEFAULT"）
+    - 許容パターン: `[A-Z][A-Z0-9]*`（英大文字で始まり、英大文字・数字のみ）
+    - 最大長: 8文字を推奨（制約は任意）
+    - 不正値は `ValueError` を raise する
+  - `title: str`
+  - `hypothesis_statement: str`
+  - `hypothesis_background: str`
+  - `status: DesignStatus` — `draft | active | supported | rejected | inconclusive`
+  - `parent_id: str | None`
+  - `metrics: dict`
+  - `created_at: datetime`
+  - `updated_at: datetime`
+- `DesignStatus` は `draft`, `active`, `supported`, `rejected`, `inconclusive` の5値を取る
+
+**FR-4: YAML ストレージ**
+- 分析設計書は `.insight/designs/` ディレクトリに YAML 形式で永続化されること
+- YAML ファイルにはアナリストが手動で追記したコメントが保持されること
+- プロジェクトパスは実行時パラメータとして受け取り、コードにハードコードしないこと
+
+**FR-5: 分析設計 CRUD**
+- 分析設計の作成:
+  - `title`, `hypothesis_statement`, `hypothesis_background`, `parent_id?`, `theme_id?` を受け取り `AnalysisDesign` を返す
+  - `id` は `{THEME_ID}-H{N:02d}` 形式で採番（テーマ内の既存 ID の最大 N + 1。削除後も衝突しない）
+  - `theme_id` 省略時は `"DEFAULT"` を使用
+  - `theme_id` は `[A-Z][A-Z0-9]*` パターンに一致すること。一致しない場合は `ValueError` を raise する（MCP layer では error dict に変換）
+  - 初期 `status` は `draft`
+  - `.insight/designs/{id}_hypothesis.yaml` として保存される（例: `FP-H01_hypothesis.yaml`）
+- 分析設計の取得:
+  - `design_id` を受け取り対応する `AnalysisDesign` を返す
+  - 存在しない場合は `None` を返す
+- 分析設計の一覧:
+  - オプションの `status` フィルタを受け取り、一致する `AnalysisDesign` のリストを返す
+  - `status` が指定されない場合はすべての設計を返す
+- CRUD 操作はプロジェクトパスを引数として受け取り、複数プロジェクト間でデータが混在しないこと
+
+**FR-6: MCP Tools（3 tools）**
+- Claude が呼び出せる MCP tool として以下の3つを提供すること:
+- `create_analysis_design(title, hypothesis_statement, hypothesis_background, parent_id?, theme_id?) → dict`
+  - `{id, title, status, message}` を返却
+- `get_analysis_design(design_id) → dict`
+  - `AnalysisDesign` を dict として返却
+  - 見つからない場合は error dict を返却
+- `list_analysis_designs(status?) → dict`
+  - `{designs: [...], count: int}` を返却
+- すべての tool は非同期 I/O に対応すること
+
+#### Acceptance Criteria
+
+1. WHEN `create_analysis_design()` is called with valid inputs THEN `{"id": "FP-H01", "status": "draft", ...}` is returned and a YAML file is saved at `.insight/designs/FP-H01_hypothesis.yaml`
+2. WHEN `get_analysis_design("FP-H01")` is called THEN the same data that was saved is returned
+3. WHEN `get_analysis_design("FP-H99")` is called for a non-existent design THEN an error dict is returned (not an exception)
+4. WHEN `list_analysis_designs(status="draft")` is called THEN only designs with `status == "draft"` are returned and `count` matches the number of results
+5. WHEN a YAML write crashes mid-write THEN the original YAML file is preserved (no partial write)
+6. WHEN `create_analysis_design()` is called with an invalid theme_id (e.g., "fp", "FP/X", "12") THEN an error dict is returned with a message indicating the invalid theme_id
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+
+- **Single Responsibility Principle**: Each file handles one specific concern (`cli.py` = entry point, `server.py` = MCP tools, `core/designs.py` = business logic, `storage/yaml_store.py` = YAML I/O)
+- **Three-Layer Separation**: CLI → Core → Storage; MCP tools delegate to `DesignService`; `DesignService` delegates to `yaml_store.py`; no cross-layer skipping
+- **One-Directional Dependencies**: Dependency direction is CLI → MCP → Core → Storage; no reverse dependencies allowed
+- **Type Annotations Required**: All functions must have complete type annotations; `ty check` must pass with no errors
+- **Code Quality**: `ruff check` passes (line-length 88); `pytest` coverage for `core/` and `storage/` is 80% or higher
+
+### Performance
+
+- CLI startup (`uvx` cold start) completes within 5 seconds (excluding first-time `uvx` package download)
+- `create_analysis_design()` completes within 100ms (local YAML write)
+- `list_analysis_designs()` completes within 200ms for up to 100 designs
+
+### Security
+
+- No hardcoded secrets, API keys, or credentials in source code
+- Project path is validated to exist before any initialization proceeds; paths are resolved to absolute via `Path.resolve()`
+- Error messages do not expose internal stack traces or file system structure to MCP clients
+
+### Reliability
+
+- All YAML writes are atomic — `tempfile.mkstemp()` + `os.replace()` ensures no partial write on crash
+- Initialization is idempotent — `uvx insight-blueprint` run multiple times does not corrupt data or duplicate files
+- `uvx insight-blueprint` works without pre-installation; Python >=3.11 is required; all runtime dependencies are installable via `uv add insight-blueprint`
+
+### Usability
+
+- `--help` output clearly describes all options and expected behavior
+- Error messages for invalid inputs (e.g., missing project path) include actionable guidance for the analyst
+- MCP tool docstrings are human-readable so Claude can accurately describe tool behavior to users
+
+## Out of Scope
+
+- データカタログ（SPEC-2）
+- レビューワークフロー（SPEC-3）
+- WebUI ダッシュボード（SPEC-4）
+- PyPI 公開（SPEC-5）
+- SQLite FTS5 index（SPEC-2）
+- FastAPI web server（SPEC-4）
+- `update_analysis_design()` MCP tool（SPEC-3、review workflow の一部）

--- a/.spec-workflow/specs/SPEC-1/tasks.md
+++ b/.spec-workflow/specs/SPEC-1/tasks.md
@@ -1,0 +1,75 @@
+# Tasks: SPEC-1 core-foundation
+
+- [x] 1.1 Initialize project scaffold and pyproject.toml
+  - File: pyproject.toml, src/insight_blueprint/__init__.py, src/insight_blueprint/__main__.py
+  - hatchling build backend を src/ layout で設定する
+  - runtime dependencies を追加: fastmcp>=2.0, pydantic>=2.10, ruamel.yaml>=0.18, click>=8.1
+  - dev dependencies を追加: pytest>=8.0, pytest-cov>=6.0, ruff>=0.8, ty>=0.1, poethepoet>=0.31
+  - poe tasks を設定: lint, typecheck, test, all
+  - Purpose: import 可能な Python package と動作する toolchain を確立する
+  - _Requirements: NFR-3, NFR-4_
+  - _Prompt: Role: Python packaging expert specializing in uv and hatchling | Task: Set up pyproject.toml for insight-blueprint with src/ layout, hatchling backend, and poethepoet task runner per requirements NFR-3 and NFR-4 | Restrictions: Do NOT use pip, use uv only; follow src/ layout convention; poe tasks must run without errors | Success: uv sync completes; python -m insight_blueprint --help shows help; insight-blueprint --help (console script) also works; poe lint passes; poe typecheck passes; poe test runs without error_
+
+- [x] 1.2 Implement Pydantic models for AnalysisDesign
+  - File: src/insight_blueprint/models/__init__.py, src/insight_blueprint/models/common.py, src/insight_blueprint/models/design.py
+  - `DesignStatus` enum を作成: draft, active, supported, rejected, inconclusive
+  - `AnalysisDesign` BaseModel を必要なフィールドと JST timezone default で作成する
+  - `theme_id: str = "DEFAULT"` フィールドを `AnalysisDesign` に追加する
+  - `AnalysisDesign` と `DesignStatus` を models/__init__.py から re-export する
+  - Purpose: storage・core・MCP 層で共有する型を定義する
+  - _Leverage: src/insight_blueprint/models/__init__.py_
+  - _Requirements: FR-3_
+  - _Prompt: Role: Python developer specializing in Pydantic v2 data modeling | Task: Implement AnalysisDesign Pydantic model and DesignStatus enum per FR-3, with JST timezone defaults using zoneinfo; include theme_id: str = "DEFAULT" field | Restrictions: Use Pydantic v2 (BaseModel, Field), all fields must have type annotations, use zoneinfo not pytz | Success: from insight_blueprint.models import AnalysisDesign, DesignStatus works; model instantiates with correct defaults including theme_id; ty check passes_
+
+- [x] 1.3 Implement YAML storage layer and project directory management
+  - File: src/insight_blueprint/storage/__init__.py, src/insight_blueprint/storage/yaml_store.py, src/insight_blueprint/storage/project.py
+  - `read_yaml(path)` を実装する（ファイルが存在しない場合は empty dict を返す）
+  - `write_yaml(path, data)` を atomic な `tempfile.mkstemp()` + `os.replace()` で実装する（ruamel.yaml でコメント保持）
+  - `init_project(project_path)` を idempotent に `.insight/` 構造を作成するよう実装する
+  - `shutil.copytree()` で初回のみ `.claude/skills/analysis-design/` をコピーする（上書きしない）
+  - `.mcp.json` に `mcpServers.insight-blueprint` を upsert する（他のサーバーは保持）
+  - `tests/test_storage.py` にテストを書く（atomic write safety、idempotent init、skills コピー、mcp.json 登録 — 14 テストケース）
+  - Purpose: すべての YAML データに対してクラッシュセーフな persistence layer を提供する
+  - _Leverage: src/insight_blueprint/models/design.py_
+  - _Requirements: FR-2, FR-4_
+  - _Prompt: Role: Python developer specializing in file system operations and atomic writes | Task: Implement atomic YAML storage and .insight/ directory init per FR-2 and FR-4 using ruamel.yaml and tempfile+os.replace pattern | Restrictions: tempfile MUST be in same directory as target for atomic os.replace; read_yaml MUST return {} not raise for missing files; init_project must be idempotent; ruamel.yaml must preserve comments in YAML files | Success: write_yaml → read_yaml でデータが完全に一致して戻る（ruamel.yaml コメントも保持）; crash simulation で元ファイルが保全される; init_project を 2 回実行してもデータ破損・例外なし; 初回実行で .claude/skills/analysis-design/ が作成される; 2 回目実行で .claude/skills/analysis-design/ が上書きされない; .mcp.json の mcpServers.insight-blueprint が登録される（既存サーバーは保持）; test_storage.py の 14 テストケースすべてが pass する_
+
+- [x] 1.4 Implement core DesignService business logic
+  - File: src/insight_blueprint/core/__init__.py, src/insight_blueprint/core/designs.py
+  - `project_path: Path` を constructor で受け取る `DesignService` class を実装する
+  - `theme_id: str = "DEFAULT"` パラメータ付きの `create_design()` を実装する
+  - ID 生成: `{THEME_ID}-H{N:02d}`（テーマ内の既存 ID の最大 N + 1。削除後も衝突しない）
+  - `theme_id` は `[A-Z][A-Z0-9]*` パターンに一致しない場合 `ValueError` を raise する
+  - missing ID に対して `None` を返す `get_design()` を実装する
+  - optional status filter 付きの `list_designs()` を実装する（ファイル名のアルファベット昇順でソート）
+  - `tests/test_designs.py` にテストを書く（happy path・not found・filtering・theme_id・invalid theme_id を含む 10件以上）
+  - Purpose: MCP tools と将来の API で共有する business logic layer
+  - _Leverage: src/insight_blueprint/storage/yaml_store.py, src/insight_blueprint/models/design.py_
+  - _Requirements: FR-5_
+  - _Prompt: Role: Python developer specializing in service layer architecture | Task: Implement DesignService with CRUD operations per FR-5, using yaml_store for persistence and AnalysisDesign model; ID format is {THEME_ID}-H{N:02d} with per-theme numbering | Restrictions: Per-theme IDs use max-N+1 (not count-based) to avoid collision on deletion; theme_id must match [A-Z][A-Z0-9]* or raise ValueError; get_design returns None not exception for missing; list_designs returns sorted by filename ascending | Success: create saves YAML at FP-H01_hypothesis.yaml; per-theme IDs number independently; get returns None for missing; list filters by status; list_designs はファイル名のアルファベット昇順（ID 昇順）でソートして返す; 不正な theme_id（例: "fp", "FP/X"）を渡すと ValueError が発生する; test_designs.py の 10+ テストケースすべてが pass する_
+
+- [x] 1.5 Implement MCP server with 3 design tools
+  - File: src/insight_blueprint/server.py, tests/test_server.py
+  - `mcp = FastMCP("insight-blueprint")` で FastMCP instance を作成する
+  - `get_service()` guard 付きの global `_service` 変数を実装する
+  - 3つの async MCP tools を登録する: create_analysis_design, get_analysis_design, list_analysis_designs
+  - `create_analysis_design()` に `theme_id: str = "DEFAULT"` パラメータを追加する
+  - `create_analysis_design()` は theme_id の ValueError を error dict に変換して返す
+  - `storage/project.py` の `init_project()` を更新して `DesignService` を `server._service` に wire する
+  - `tests/test_server.py` にテストを書く（design.md 記載の 5 テストケース全て）
+  - Purpose: MCP protocol 経由で design 操作を Claude Code に公開する
+  - _Leverage: src/insight_blueprint/core/designs.py, src/insight_blueprint/models/design.py_
+  - _Requirements: FR-6_
+  - _Prompt: Role: Python developer specializing in FastMCP and MCP protocol | Task: Implement 3 MCP tools using fastmcp @mcp.tool() decorator per FR-6; tools must be async; create_analysis_design accepts theme_id: str = "DEFAULT" and passes to service; get_analysis_design returns error dict not exception for missing ID; create_analysis_design converts ValueError from invalid theme_id to error dict | Restrictions: Use fastmcp not mcp.server.fastmcp; all tools async def; return dicts not Pydantic models directly; wire _service in init_project | Success: 3 tools registered; create returns {id: "FP-H01", title, status, message} when called with theme_id="FP"; create returns error dict for invalid theme_id (e.g., "fp"); get returns error dict for missing ID (not exception); list returns {designs: [...], count: N}; get_service() raises RuntimeError before init_project() is called; test_server.py の 5 テストケース（design.md 記載）すべてが pass する_
+
+- [x] 1.6 Implement CLI entry point and run end-to-end integration test
+  - File: src/insight_blueprint/cli.py, src/insight_blueprint/__main__.py, tests/test_integration.py, README.md
+  - `--project` と `--headless` option を持つ click CLI を実装する
+  - 存在しない project path に対して `ClickException` を追加する
+  - `python -m insight_blueprint` サポートのために `__main__.py` を作成する
+  - integration test を書く: `.insight/` init → create_design (theme_id="FP") → get_design("FP-H01") → list_designs round-trip
+  - `poe all` が通ることを確認する（ruff + ty + pytest、`core/` と `storage/` の coverage が 80% 以上）
+  - Purpose: 使用可能な CLI entry point を完成させ、end-to-end の動作を検証する
+  - _Leverage: src/insight_blueprint/server.py, src/insight_blueprint/storage/project.py_
+  - _Requirements: FR-1, AC-1, AC-2, AC-3, AC-5_
+  - _Prompt: Role: Python developer specializing in click CLIs and integration testing | Task: Implement CLI entry point per FR-1 with click, add integration test covering full round-trip per AC-1 through AC-5, ensure poe all passes with >=80% coverage | Restrictions: mcp.run() must be LAST call in main(); ClickException for missing project path; --headless suppresses browser (no-op in SPEC-1); README must have install and quick-start | Success: uvx insight-blueprint --project /path creates .insight/ and starts MCP server; uvx insight-blueprint --project /nonexistent exits with exit code 1 (AC-1-3); uvx insight-blueprint (no --project) uses current directory as project root (AC-1-2); poe all passes (ruff + typecheck + pytest); coverage for core/ and storage/ is 80% or higher; README.md に install セクションと quick-start セクションが存在する_

--- a/.spec-workflow/specs/SPEC-1a/design.md
+++ b/.spec-workflow/specs/SPEC-1a/design.md
@@ -1,0 +1,267 @@
+# SPEC-1a: hypothesis-enrichment — 設計
+
+> **Spec ID**: SPEC-1a
+> **Status**: completed (retroactive spec)
+> **Created**: 2026-02-22
+> **Depends On**: SPEC-1 (core-foundation)
+
+---
+
+## 概要
+
+SPEC-1a は SPEC-1 で確立した 3 層アーキテクチャ（CLI → MCP → Core → Storage）を壊さずに
+`AnalysisDesign` モデルを拡張し、`update_analysis_design()` MCP ツールを追加する。
+変更対象は `models/design.py`・`core/designs.py`・`server.py`・`_skills/analysis-design/SKILL.md`
+の 4 ファイルのみであり、ストレージ層・CLI・テストインフラは変更しない。
+
+## ステアリングドキュメントとの整合
+
+### 技術標準（tech.md）
+
+- **YAGNI**: フィールド型は `list[dict]` / `dict | None` とし、`ExplanatoryVariable` や
+  `ChartSpec` 等の型付きサブモデルは SPEC-3 以降まで導入しない
+- **Pydantic v2**: `model_copy(update=...)` パターンで部分更新を実現。`model.copy()` (v1 API)
+  は使用しない
+- **アトミック書き込み**: `update_design()` も `write_yaml()` を経由することで、
+  SPEC-1 のクラッシュセーフ保証を引き継ぐ
+- **型アノテーション**: すべての関数・メソッドに完全な型アノテーションを付与し、`ty check` エラーゼロを維持
+- **TDD**: 各変更はテストファースト（Red → Green → Refactor）で実装
+
+### プロジェクト構造（structure.md）
+
+- **単方向依存の維持**: `server.py` → `core/designs.py` → `storage/` の依存方向は変わらない
+- **ファイル単一責任**: フィールド追加は `models/design.py`、ビジネスロジックは `core/designs.py`、
+  MCP ツールは `server.py` にのみ変更を加える
+
+## コード再利用分析
+
+### 活用できる既存コンポーネント
+
+- **`models/design.py: AnalysisDesign`**: 既存モデルに 3 フィールドを追記するのみ。
+  Pydantic の `Field(default_factory=list)` と `= None` デフォルトで後方互換を保証する
+- **`core/designs.py: DesignService`**: `update_design()` を追加する。
+  `get_design()` / `write_yaml()` の既存実装を内部で再利用する
+- **`storage/yaml_store.py: write_yaml()`**: `update_design()` の永続化に再利用。
+  ストレージ層の変更なし
+- **`models/common.py: now_jst()`**: `update_design()` での `updated_at` 更新に再利用
+
+### 統合ポイント
+
+- **`server.py: update_analysis_design()`**: SPEC-1 の `create_analysis_design()` / `get_analysis_design()`
+  と同じ `get_service()` パターンを踏襲する
+- **既存テスト**: `tests/test_designs.py` / `tests/test_server.py` に SPEC-1a 向けのテストケースを追記する
+
+## アーキテクチャ
+
+### モジュラー設計原則
+
+- **ファイル単一責任**: 追加フィールドは `models/design.py` のみ。`update_design()` は `core/designs.py` のみ。
+  MCP ツールは `server.py` のみ。一切の層越えは行わない
+- **コンポーネント分離**: `DesignService.update_design()` は `server.py` や `cli.py` を知らない。
+  独立してユニットテスト可能
+- **サービス層分離**: `update_analysis_design()` (MCP tool) → `update_design()` (DesignService)
+  → `write_yaml()` (yaml_store) の 3 段を維持
+
+```
+Claude Code (AI Client)
+       |
+  stdio (MCP Protocol)
+       |
+  server.py
+    ├── create_analysis_design(... explanatory?, chart?, next_action?)  [SPEC-1 + 拡張]
+    ├── update_analysis_design(design_id, *fields)                      [SPEC-1a 新規]
+    ├── get_analysis_design(design_id)
+    └── list_analysis_designs(status?)
+           ↓
+  core/designs.py: DesignService
+    ├── create_design(... explanatory?, chart?, next_action?)            [SPEC-1 + 拡張]
+    └── update_design(design_id, **fields) → AnalysisDesign | None      [SPEC-1a 新規]
+           ↓
+  storage/yaml_store.py
+    └── write_yaml()  [変更なし]
+           ↓
+  .insight/designs/{id}_hypothesis.yaml
+```
+
+### 設計決定: `list[dict]` / `dict | None` で YAGNI
+
+**選択**: `explanatory: list[dict]`、`chart: list[dict]`、`next_action: dict | None`
+
+**理由**: 現時点でバリデーションが必要な上位呼び出し元（Claude Code）は辞書構造を知っている。
+型付きサブモデル（`ExplanatoryVariable`, `ChartSpec` 等）を今導入しても、
+SPEC-3 でレビューワークフローが確定する前に破壊的変更が生じるリスクがある。
+`list[dict]` は「いつでも型付きサブモデルに昇格できる」経路を閉じない。
+
+### 設計決定: `model_copy(update=...)` パターン
+
+**選択**: `updated = design.model_copy(update={**fields, "updated_at": now_jst()})`
+
+**理由**:
+- Pydantic v2 の推奨 API（`model.copy()` は v1 互換の非推奨 API）
+- `update` dict のキーのみが上書きされ、他フィールドは元の値を引き継ぐ
+- イミュータブルな操作のため、更新中に元オブジェクトが変更されない
+- `now_jst()` をこの時点で注入することで `updated_at` の更新漏れを防ぐ
+
+### 設計決定: `None` 引数のスキップ
+
+`update_analysis_design()` MCP ツールでは、`None` の引数を更新対象から除外する:
+
+```python
+updates = {k: v for k, v in {...}.items() if v is not None}
+```
+
+**理由**: MCP プロトコルでは省略パラメータが `None` として渡される。
+`None` を「フィールドを `None` にセット」と解釈すると、
+`next_action` を `None` に戻す操作が「引数省略」と区別できなくなる。
+SPEC-1a では「省略 = 変更しない」のセマンティクスを採用し、
+将来の「明示的に None をセット」ユースケースは SPEC-3 以降で対応する。
+
+## コンポーネントとインターフェース
+
+### `models/design.py` (拡張)
+
+- **目的**: `AnalysisDesign` に 3 つの enrichment フィールドを追加。後方互換保証
+- **変更内容**:
+  ```python
+  explanatory: list[dict] = Field(default_factory=list)
+  chart: list[dict] = Field(default_factory=list)
+  next_action: dict | None = None
+  ```
+- **依存関係**: 変更なし
+- **後方互換**: Pydantic がデフォルト値を補完するため、既存 YAML（フィールドなし）は変更なしにロードされる
+
+### `core/designs.py: DesignService` (拡張)
+
+- **目的**: `update_design()` の追加。`create_design()` の optional パラメータ拡張
+- **インターフェース追加**:
+  - `update_design(design_id: str, **fields: object) -> AnalysisDesign | None`
+    - `get_design()` で現在値を取得 → `model_copy(update=...)` で新オブジェクト生成 → `write_yaml()` で永続化
+    - 存在しない `design_id` → `None` を返す（例外なし）
+  - `create_design()` に `explanatory`, `chart`, `next_action` optional params 追加
+- **依存関係**: `models/common.py:now_jst`（追加）、他は変更なし
+- **再利用**: `get_design()`, `write_yaml()` を内部で再利用
+
+### `server.py: update_analysis_design()` (新規)
+
+- **目的**: `update_design()` を Claude から呼び出せる MCP ツールとして公開
+- **インターフェース**:
+  ```python
+  async def update_analysis_design(
+      design_id: str,
+      title: str | None = None,
+      hypothesis_statement: str | None = None,
+      hypothesis_background: str | None = None,
+      status: str | None = None,
+      metrics: dict | None = None,
+      explanatory: list[dict] | None = None,
+      chart: list[dict] | None = None,
+      next_action: dict | None = None,
+  ) -> dict
+  ```
+- **戻り値**:
+  - 成功: `design.model_dump(mode="json")`（全フィールド含む完全な dict）
+  - `design_id` 不存在: `{"error": "Design '{design_id}' not found"}`
+  - 不正 `status`: `{"error": "Invalid status '{status}'"}`
+- **依存関係**: `core/designs.py:DesignService`、`models/design.py:DesignStatus`
+
+### `_skills/analysis-design/SKILL.md` (更新)
+
+- **目的**: Claude に `update_analysis_design()` ツールの存在と使い方を伝える
+- **変更内容**: Step 2 テーブルに `update_analysis_design` 行を追加、ツールリファレンスセクションを更新
+
+## データモデル
+
+### 拡張後の `.insight/designs/{id}_hypothesis.yaml`
+
+```yaml
+id: FP-H01
+theme_id: FP
+title: Foreign population vs crime rate correlation
+hypothesis_statement: No positive correlation exists between...
+hypothesis_background: |
+  ...
+status: draft
+parent_id: null
+metrics: {}
+explanatory:
+  - variable: foreign_population_ratio
+    description: Prefecture-level ratio of foreign residents
+    dtype: float
+    source: e-stat stat_id:00200521
+chart:
+  - type: scatter
+    x: foreign_population_ratio
+    y: crime_rate_per_10k
+    title: Foreign Population vs Crime Rate
+next_action:
+  action: collect_data
+  target: e-stat API
+  rationale: Need official prefecture-level statistics
+created_at: "2026-02-22T10:00:00+09:00"
+updated_at: "2026-02-22T10:15:00+09:00"
+```
+
+**後方互換**: SPEC-1 が生成した既存 YAML（`explanatory`/`chart`/`next_action` なし）は
+Pydantic がデフォルト値（`[]`, `[]`, `None`）で補完するため変更不要。
+
+## エラーハンドリング
+
+1. **`design_id` 不存在** — `update_analysis_design("NONE-H99")` で設計が存在しない場合
+   - **ハンドリング**: `DesignService.update_design()` が `None` を返す。`server.py` が `{"error": "Design 'NONE-H99' not found"}` に変換する
+   - **ユーザーへの影響**: Claude がエラー dict を受け取り、IDが不正であることをアナリストに伝える
+
+2. **不正な `status` 値** — `update_analysis_design("FP-H01", status="invalid")` の場合
+   - **ハンドリング**: `DesignStatus("invalid")` が `ValueError` を raise。`server.py` が `{"error": "Invalid status 'invalid'"}` に変換する
+   - **ユーザーへの影響**: Claude が有効なステータス値（draft/active/supported/rejected/inconclusive）をアナリストに案内する
+
+3. **引数なし呼び出し** — `update_analysis_design("FP-H01")` でフィールド引数がすべて `None` の場合
+   - **ハンドリング**: `updates` dict が空 → `model_copy(update={"updated_at": now_jst()})` のみが実行される。設計は `updated_at` だけ更新されて返却される
+   - **ユーザーへの影響**: 冪等に近い動作（`updated_at` のみ変化）。エラーにはならない
+
+4. **YAML 書き込み失敗** — `write_yaml()` 実行中に I/O エラーが発生した場合
+   - **ハンドリング**: SPEC-1 と同じ — `os.replace()` が呼ばれる前に失敗するため、元ファイルは保全される
+   - **ユーザーへの影響**: `update_analysis_design()` が MCP エラーレスポンスを返す。リトライ可能
+
+## テスト戦略
+
+### ユニットテスト
+
+**`tests/test_designs.py` への追加テストケース:**
+- `test_create_design_with_enrichment_fields` — `explanatory`, `chart`, `next_action` 付き作成
+- `test_create_design_without_enrichment_defaults_to_empty` — 省略時のデフォルト確認
+- `test_update_design_changes_only_specified_fields` — 部分更新の正確性
+- `test_update_design_refreshes_updated_at` — `updated_at` の自動更新
+- `test_update_design_returns_none_for_missing_id` — 不存在 ID で `None`
+- `test_update_design_with_no_fields_only_updates_timestamp` — フィールドなし呼び出し
+
+**`tests/test_server.py` への追加テストケース:**
+- `test_update_analysis_design_partial_update` — 1 フィールドのみ更新
+- `test_update_analysis_design_returns_error_for_missing_design` — 不存在 ID
+- `test_update_analysis_design_returns_error_for_invalid_status` — 不正 status
+- `test_update_analysis_design_updates_enrichment_fields` — `explanatory`/`chart`/`next_action` 更新
+
+### インテグレーションテスト
+
+- `tests/test_integration.py` への追加:
+  - `create_design()` → `update_design()` → `get_design()` のラウンドトリップで部分更新が保存されることを確認
+  - 既存 YAML（enrichment フィールドなし）をロードし、デフォルト値が補完されることを確認
+
+### E2E テスト
+
+MCP プロトコル E2E テストは SPEC-1a のスコープ外（SPEC-1 と同様の方針）。
+ユニット + インテグレーションテストが全 AC をカバーする。
+
+### AC × テストケース 対応表
+
+| AC | 内容（要約） | テストケース | ファイル |
+|----|-------------|-------------|---------|
+| 1-1 | enrichment フィールドなし作成 → デフォルト値 | `test_create_design_without_enrichment_defaults_to_empty` | `test_designs.py` |
+| 1-2 | `explanatory` 付き作成 → YAML に保存 | `test_create_design_with_enrichment_fields` | `test_designs.py` |
+| 1-3 | 既存 YAML（フィールドなし）ロード → エラーなし | `test_integration.py` でラウンドトリップ確認 | `test_integration.py` |
+| 1-4 | `AnalysisDesign(...)` フィールドなし → `explanatory==[]` | `test_create_design_without_enrichment_defaults_to_empty` | `test_designs.py` |
+| 2-1 | 1 フィールドのみ更新 → 他は保持 | `test_update_design_changes_only_specified_fields` | `test_designs.py` |
+| 2-2 | `explanatory` 更新 → YAML に保存 | `test_update_analysis_design_updates_enrichment_fields` | `test_server.py` |
+| 2-3 | 不存在 ID → error dict | `test_update_analysis_design_returns_error_for_missing_design` | `test_server.py` |
+| 2-4 | 不正 status → error dict | `test_update_analysis_design_returns_error_for_invalid_status` | `test_server.py` |
+| 2-5 | フィールドなし呼び出し → `updated_at` のみ変化 | `test_update_design_with_no_fields_only_updates_timestamp` | `test_designs.py` |
+| 2-6 | `next_action` 更新 → 保存確認 | `test_update_analysis_design_updates_enrichment_fields` | `test_server.py` |

--- a/.spec-workflow/specs/SPEC-1a/requirements.md
+++ b/.spec-workflow/specs/SPEC-1a/requirements.md
@@ -1,0 +1,145 @@
+# SPEC-1a: hypothesis-enrichment — Requirements
+
+> **Spec ID**: SPEC-1a
+> **Feature Name**: hypothesis-enrichment
+> **Status**: completed (retroactive spec)
+> **Created**: 2026-02-22
+> **Depends On**: SPEC-1 (core-foundation)
+
+---
+
+## Introduction
+
+SPEC-1a extends the `AnalysisDesign` model introduced in SPEC-1 with three enrichment fields
+(`explanatory`, `chart`, `next_action`) that allow Claude Code to record the analytical plan
+alongside each hypothesis. It also adds an `update_analysis_design()` MCP tool so Claude can
+iteratively refine existing designs without recreating them. These additions are fully
+backward-compatible — existing YAML files produced by SPEC-1 remain valid and load without
+migration.
+
+## Alignment with Product Vision
+
+- **Lightweight analysis design docs**: `explanatory`, `chart`, and `next_action` capture
+  the analytical intent (variables, visualizations, follow-up actions) in the same YAML
+  document, reducing round-trips between tools and keeping the design self-contained.
+- **Claude Code integration**: `update_analysis_design()` enables Claude to refine a hypothesis
+  after collecting analyst feedback, supporting iterative EDA workflows without re-creating
+  designs from scratch.
+- **Spec Roadmap foundation**: The enrichment fields establish the schema that SPEC-2
+  (catalog integration) and SPEC-3 (review workflow) will populate; SPEC-1a is a prerequisite
+  for those specs.
+
+## Requirements
+
+### Requirement 1: 仮説エンリッチメントフィールド
+
+**User Story:** As a data scientist, I want Claude to record the list of explanatory variables,
+planned charts, and next analysis actions together with each hypothesis, so that the design
+document is self-contained and I can hand it off or review it without switching to another
+tool.
+
+**FR-1: AnalysisDesign フィールド拡張**
+- `AnalysisDesign` モデルに以下のフィールドを追加すること（すべて optional、デフォルト値あり）:
+  - `explanatory: list[dict]` — 説明変数リスト（デフォルト: `[]`）
+    - 各要素の推奨キー: `variable`, `description`, `dtype`, `source`（強制なし）
+  - `chart: list[dict]` — 可視化計画リスト（デフォルト: `[]`）
+    - 各要素の推奨キー: `type`, `x`, `y`, `title`（強制なし）
+  - `next_action: dict | None` — 次ステップ記述（デフォルト: `None`）
+    - 推奨キー: `action`, `target`, `rationale`（強制なし）
+- 追加フィールドは後方互換であること:
+  - SPEC-1 が生成した既存 YAML（これらのフィールドを含まない）は、デフォルト値で正常にロードされること
+  - 既存 YAML の書き換えやマイグレーション処理は不要であること
+
+**FR-2: create_analysis_design() オプションパラメータ拡張**
+- 既存の `create_analysis_design()` MCP tool が新フィールドを optional パラメータとして受理すること:
+  - `explanatory: list[dict] | None = None`
+  - `chart: list[dict] | None = None`
+  - `next_action: dict | None = None`
+- パラメータ省略時はデフォルト値（空リスト、None）が使用されること
+- 既存のシグネチャ（`title`, `hypothesis_statement`, `hypothesis_background`, `parent_id?`, `theme_id?`）は変更しないこと
+
+#### Acceptance Criteria
+
+1. WHEN `create_analysis_design()` is called without `explanatory`, `chart`, or `next_action`
+   THEN a valid AnalysisDesign is created with `explanatory=[]`, `chart=[]`, `next_action=None`
+2. WHEN `create_analysis_design()` is called with `explanatory=[{"variable": "age"}]`
+   THEN the YAML file at `.insight/designs/` contains the `explanatory` field with that value
+3. WHEN an existing YAML file produced by SPEC-1 (no enrichment fields) is loaded
+   THEN it loads without error and enrichment fields are populated with their defaults
+4. WHEN `AnalysisDesign` is instantiated from a YAML dict that lacks `explanatory`
+   THEN `design.explanatory` equals `[]` (Pydantic default)
+
+### Requirement 2: 分析設計の部分更新
+
+**User Story:** As a data scientist, I want Claude to call `update_analysis_design()` with only
+the fields I want to change, so that I can iteratively refine a hypothesis without losing
+previously recorded data.
+
+**FR-3: update_design() ビジネスロジック**
+- `DesignService.update_design(design_id, **fields)` を実装すること:
+  - 指定されたフィールドのみを上書きし、その他のフィールドは保持すること
+  - `updated_at` は常に現在時刻（JST）に更新されること
+  - Pydantic v2 の `model_copy(update=...)` パターンを使用すること
+  - `design_id` が存在しない場合は `None` を返すこと（例外を raise しないこと）
+  - 更新後の `AnalysisDesign` を YAML として保存し、返すこと
+
+**FR-4: update_analysis_design() MCP Tool**
+- Claude が呼び出せる MCP tool として `update_analysis_design()` を追加すること:
+  - シグネチャ: `update_analysis_design(design_id, title?, hypothesis_statement?, hypothesis_background?, status?, metrics?, explanatory?, chart?, next_action?) → dict`
+  - すべてのフィールドパラメータは optional（`None` 省略時は更新しない）
+  - 成功時: 更新後の AnalysisDesign を dict として返す
+  - `design_id` 不存在時: `{"error": "Design '{design_id}' not found"}` を返す（例外なし）
+  - `status` に不正値が指定された場合: `{"error": "Invalid status '{status}'"}` を返す
+  - `None` フィールドは更新対象から除外すること（False や空文字列は更新対象とする）
+
+#### Acceptance Criteria
+
+1. WHEN `update_analysis_design("FP-H01", title="New Title")` is called on an existing design
+   THEN only `title` and `updated_at` are changed; all other fields retain their previous values
+2. WHEN `update_analysis_design("FP-H01", explanatory=[{"variable": "age"}])` is called
+   THEN the YAML file is updated and `design.explanatory == [{"variable": "age"}]`
+3. WHEN `update_analysis_design("NONE-H99")` is called for a non-existent design
+   THEN `{"error": "Design 'NONE-H99' not found"}` is returned (no exception raised)
+4. WHEN `update_analysis_design("FP-H01", status="invalid_value")` is called
+   THEN `{"error": "Invalid status 'invalid_value'"}` is returned
+5. WHEN `update_analysis_design("FP-H01")` is called with no field arguments
+   THEN only `updated_at` is refreshed and all other fields remain unchanged
+6. WHEN `update_analysis_design("FP-H01", next_action={"action": "collect more data"})` is called
+   THEN `design.next_action == {"action": "collect more data"}`
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+
+- **Single Responsibility Principle**: フィールド追加は `models/design.py` のみ、ビジネスロジックは `core/designs.py` のみ、MCP tool は `server.py` のみを修正すること
+- **Backward Compatibility**: 新フィールドはすべて Pydantic `Field(default_factory=...)` または `= None` とし、既存 YAML の読み込みを壊さないこと
+- **YAGNI**: フィールドの型は `list[dict]` / `dict | None` とし、サブモデル（`ExplanatoryVariable`, `ChartSpec` 等）は SPEC-3 以降まで導入しないこと
+- **Type Annotations**: すべての関数に完全な型アノテーションを付与すること（`ty check` エラーゼロ）
+
+### Performance
+
+- `update_analysis_design()` は 100ms 以内に完了すること（ローカル YAML 読み書き）
+- モデルへのフィールド追加は startup time に影響しないこと
+
+### Security
+
+- フィールド値（`list[dict]`）にシェルコマンドや SQL クエリが含まれていても、ストレージ層はそのまま YAML に保存するだけであること（実行しないこと）
+- MCP tool のエラーレスポンスにスタックトレースや内部ファイルパスを含めないこと
+
+### Reliability
+
+- `update_design()` は `write_yaml()` の atomic write（`tempfile.mkstemp()` + `os.replace()`）を経由するため、クラッシュ時に元ファイルが破損しないこと
+- `model_copy(update=...)` は新しいオブジェクトを生成するため、更新中の元データは変更されないこと
+
+### Usability
+
+- `update_analysis_design()` の docstring は Claude が各パラメータの意味を正確に把握できる程度に記述すること
+- `explanatory`, `chart`, `next_action` フィールドのキー構造はドキュメント上「推奨」であり、Claude が任意の dict 構造を渡せること
+
+## Out of Scope
+
+- `data_source` フィールドの追加（SPEC-2: catalog integration で実装）
+- `ExplanatoryVariable`, `ChartSpec` 等の型付きサブモデル（SPEC-3 以降）
+- `explanatory` / `chart` の JSON Schema バリデーション（SPEC-3 以降）
+- レビューワークフロー（SPEC-3）
+- WebUI での enrichment フィールド表示（SPEC-4）

--- a/.spec-workflow/specs/SPEC-1a/tasks.md
+++ b/.spec-workflow/specs/SPEC-1a/tasks.md
@@ -1,0 +1,49 @@
+# SPEC-1a: hypothesis-enrichment — Tasks
+
+> **Status**: All tasks completed (retroactive spec)
+> **Completed**: 2026-02-22
+
+---
+
+- [x] 1.1 Add enrichment fields to AnalysisDesign model and update tests
+  - File: `src/insight_blueprint/models/design.py`, `tests/test_designs.py`
+  - Add `explanatory: list[dict]`, `chart: list[dict]`, `next_action: dict | None` fields to `AnalysisDesign`
+  - All fields must have defaults (`Field(default_factory=list)` / `= None`) for backward compatibility
+  - Update `tests/test_designs.py`: add tests for enrichment fields (create with/without, YAML round-trip, backward compat loading)
+  - Purpose: Extend the data model so hypothesis documents can capture analytical intent inline
+  - _Leverage: `src/insight_blueprint/models/common.py:now_jst`, `pydantic.Field`_
+  - _Requirements: FR-1, FR-2_
+  - _Prompt: Role: Python developer specializing in Pydantic v2 data models | Task: Implement the task for spec SPEC-1a, first run spec-workflow-guide to get the workflow guide then implement the task: Add enrichment fields to AnalysisDesign following FR-1 and FR-2 with full backward compatibility | Restrictions: All new fields must be optional with defaults; do not break existing YAML round-trips | Success: ty check passes, tests pass, existing YAML files load without error_
+
+- [x] 1.2 Add update_design() to DesignService and extend create_design() params
+  - File: `src/insight_blueprint/core/designs.py`, `tests/test_designs.py`
+  - Add `update_design(design_id: str, **fields: object) -> AnalysisDesign | None` using `model_copy(update=...)` pattern
+  - Extend `create_design()` with optional `explanatory`, `chart`, `next_action` params
+  - `update_design()` must refresh `updated_at` automatically via `now_jst()`
+  - Update `tests/test_designs.py`: partial update, `updated_at` refresh, missing ID returns `None`, no-field call
+  - Purpose: Provide iterative refinement without recreating designs from scratch
+  - _Leverage: `storage/yaml_store.py:write_yaml`, `models/common.py:now_jst`, `pydantic BaseModel.model_copy`_
+  - _Requirements: FR-3_
+  - _Prompt: Role: Python developer specializing in Pydantic v2 service patterns | Task: Implement the task for spec SPEC-1a, first run spec-workflow-guide to get the workflow guide then implement the task: Add update_design() to DesignService using model_copy(update=...) following FR-3 | Restrictions: Use model_copy not model.copy(); always inject updated_at via now_jst(); missing ID must return None not raise | Success: All new tests pass, partial update leaves untouched fields intact_
+
+- [x] 1.3 Add update_analysis_design() MCP tool to server.py and update tests
+  - File: `src/insight_blueprint/server.py`, `tests/test_server.py`
+  - Add `async update_analysis_design(design_id, title?, hypothesis_statement?, hypothesis_background?, status?, metrics?, explanatory?, chart?, next_action?) -> dict` with `@mcp.tool()` decorator
+  - Skip `None` arguments via dict comprehension (`{k: v for k, v in ... if v is not None}`)
+  - Handle invalid `status` → `{"error": "Invalid status '...'"}` before calling `update_design()`
+  - Handle missing design → `{"error": "Design '...' not found"}`
+  - Success → return `design.model_dump(mode="json")`
+  - Update `tests/test_server.py`: partial update, missing ID error, invalid status error, enrichment field update
+  - Purpose: Expose partial-update capability to Claude Code via MCP protocol
+  - _Leverage: `server.py:get_service`, `models/design.py:DesignStatus`, `core/designs.py:DesignService.update_design`_
+  - _Requirements: FR-4_
+  - _Prompt: Role: Python developer specializing in FastMCP tool implementation | Task: Implement the task for spec SPEC-1a, first run spec-workflow-guide to get the workflow guide then implement the task: Add update_analysis_design() MCP tool following FR-4 | Restrictions: Skip None params; return error dicts not exceptions; follow existing get_service() pattern | Success: All server tests pass, invalid inputs return proper error dicts_
+
+- [x] 1.4 Update _skills/analysis-design/SKILL.md with update tool reference
+  - File: `src/insight_blueprint/_skills/analysis-design/SKILL.md`
+  - Add `update_analysis_design` to the Step 2 tool table and tool reference section
+  - Document all optional parameters and error response formats
+  - Purpose: Ensure Claude Code knows about the new update tool when reading the bundled skill
+  - _Leverage: existing `SKILL.md` structure_
+  - _Requirements: FR-4_
+  - _Prompt: Role: Technical writer for Claude Code skills | Task: Implement the task for spec SPEC-1a, first run spec-workflow-guide to get the workflow guide then implement the task: Update SKILL.md to document update_analysis_design() following FR-4 usability NFR | Restrictions: Keep SKILL.md under 300 lines; preserve existing frontmatter and structure | Success: SKILL.md clearly describes update_analysis_design() parameters and error responses_

--- a/.spec-workflow/specs/SPEC-2/design.md
+++ b/.spec-workflow/specs/SPEC-2/design.md
@@ -1,0 +1,510 @@
+# SPEC-2: data-catalog — Design
+
+> **Spec ID**: SPEC-2
+> **Status**: pending_approval
+> **Created**: 2026-02-24
+> **Depends On**: SPEC-1 (core-foundation), SPEC-1a (hypothesis-enrichment)
+
+---
+
+## Overview
+
+SPEC-2 adds a data catalog layer to insight-blueprint. Data scientists register data
+sources (CSV, API, SQL) with column-level schema information, and Claude Code searches
+across sources and domain knowledge via FTS5 full-text search. The catalog follows the
+same 3-layer architecture as SPEC-1: MCP tools (server.py) → CatalogService (core/catalog.py)
+→ Storage (yaml_store.py + sqlite_store.py). YAML files remain the source of truth;
+SQLite FTS5 is a derived index rebuilt on startup and updated incrementally when
+sources are added or updated during a session.
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+
+- **Storage**: Per-source YAML files in `.insight/catalog/sources/{id}.yaml` and
+  `.insight/catalog/knowledge/{id}.yaml` — YAML remains source of truth per tech.md mandate
+- **Search index**: SQLite FTS5 via stdlib `sqlite3` with `trigram` tokenizer — full
+  rebuild from YAML on startup per tech.md startup sequence (step 5), plus incremental
+  updates on `add_source()` and `update_source()` during a session
+- **MCP tools**: 5 new async tools registered with `@mcp.tool()` on the existing
+  `FastMCP("insight-blueprint")` instance
+- **Quality**: TDD (Red-Green-Refactor), ruff + ty + pytest, 80%+ coverage target
+- **No new dependencies**: Uses stdlib `sqlite3` for FTS5 — no additional packages
+
+### Project Structure (structure.md)
+
+- **New modules** per Spec-to-Module Mapping: `models/catalog.py`, `storage/sqlite_store.py`,
+  `core/catalog.py`
+- **Modified modules**: `server.py` (+5 tools), `cli.py` (+CatalogService wiring),
+  `storage/project.py` (+sources dir, +.sqlite dir, +catalog-register skill copy)
+- **3-layer separation**: MCP tools → CatalogService → yaml_store + sqlite_store
+- **One-directional dependencies**: server.py → core/catalog.py → storage/*
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+
+- **`now_jst()`** (`models/common.py`): Timestamps for `DataSource.created_at/updated_at`
+- **`read_yaml/write_yaml`** (`storage/yaml_store.py`): All YAML persistence for sources
+  and knowledge files — atomic writes via `tempfile.mkstemp()` + `os.replace()`
+- **`DesignService` pattern** (`core/designs.py`): CatalogService follows the same structure:
+  constructor with `project_path`, glob-based listing, `model_copy(update=...)` for partial
+  updates, `_dir` path convention
+- **`get_service()` guard pattern** (`server.py`): `get_catalog_service()` follows same
+  `RuntimeError` guard for uninitialized service
+- **`_copy_skills_template`** (`storage/project.py`): Extended to also copy `catalog-register`
+  skill from bundled `_skills/`
+- **MCP error dict pattern** (`server.py`): `ValueError` → `{"error": str(e)}` conversion
+- **`tmp_project` fixture** (`tests/conftest.py`): Reused for all catalog tests
+
+### Integration Points
+
+- **`server.py`**: New `_catalog_service` module-level reference + 5 `@mcp.tool()` functions
+  added alongside existing 4 design tools
+- **`cli.py`**: `CatalogService` instantiated and wired before `mcp.run()`;
+  `rebuild_index()` called after wiring
+- **`storage/project.py`**: `_create_insight_dirs()` extended to create `catalog/sources/`
+  directory and `.sqlite/` directory; `_copy_skills_template()` extended for catalog-register
+
+## Architecture
+
+### Modular Design Principles
+
+- **Single File Responsibility**: `models/catalog.py` = data models only,
+  `storage/sqlite_store.py` = FTS5 index only, `core/catalog.py` = CRUD + search logic only
+- **Component Isolation**: `sqlite_store.py` has no dependency on Pydantic models —
+  receives plain dicts for indexing. `CatalogService` orchestrates YAML and FTS5 layers
+- **Service Layer Separation**: MCP tools → CatalogService → yaml_store + sqlite_store.
+  No cross-layer skipping
+- **Utility Modularity**: FTS5 operations isolated in `sqlite_store.py` — easy to replace
+  with alternative search backend if needed
+
+### Component Diagram (SPEC-2 additions)
+
+```
+Claude Code (AI Client)
+       |
+  stdio (MCP Protocol)
+       |
+  +------------------------------------------+
+  |  insight-blueprint (Python Process)      |
+  |                                          |
+  |  cli.py (entry point)                    |
+  |    ├── init_project()                    |
+  |    ├── wire DesignService                |
+  |    ├── wire CatalogService  ← NEW        |
+  |    ├── rebuild_index()      ← NEW        |
+  |    └── mcp.run() ← BLOCKS               |
+  |                                          |
+  |  server.py (FastMCP)                     |
+  |    ├── [4 existing design tools]         |
+  |    ├── add_catalog_entry        ← NEW    |
+  |    ├── update_catalog_entry     ← NEW    |
+  |    ├── get_table_schema         ← NEW    |
+  |    ├── search_catalog           ← NEW    |
+  |    └── get_domain_knowledge     ← NEW    |
+  |           ↓                              |
+  |  core/catalog.py (CatalogService) ← NEW |
+  |           ↓                              |
+  |  storage/yaml_store.py (existing)        |
+  |  storage/sqlite_store.py (FTS5)   ← NEW |
+  +------------------------------------------+
+           ↓
+  .insight/
+    ├── catalog/
+    │   ├── sources/          ← NEW (per-file)
+    │   │   ├── estat-population.yaml
+    │   │   └── bq-sales-data.yaml
+    │   └── knowledge/        (existing dir)
+    │       ├── estat-population.yaml
+    │       └── bq-sales-data.yaml
+    ├── .sqlite/              ← NEW
+    │   └── catalog_fts.db
+    ├── designs/
+    └── rules/
+```
+
+### Design Decision: FTS5 Trigram Tokenizer
+
+Based on R1 research (`.claude/docs/research/spec2-fts5-tokenizer.md`):
+
+- **unicode61** (default) is unsuitable for Japanese — relies on whitespace for word
+  boundaries, which CJK languages lack
+- **trigram** tokenizer indexes every 3-character sequence — works for both Japanese
+  and English queries of 3+ characters with zero external dependencies
+- **Limitation**: Queries shorter than 3 characters return no FTS5 matches. Acceptable
+  for our use case since catalog search terms are typically descriptive words/phrases
+- **ICU tokenizer** provides better linguistic quality but requires C extension compilation,
+  violating the zero-install distribution goal
+
+```sql
+CREATE VIRTUAL TABLE IF NOT EXISTS catalog_fts USING fts5(
+    doc_type, source_id, title, content,
+    tokenize='trigram'
+);
+```
+
+### Design Decision: Per-Source File Storage
+
+Following the same pattern as `DesignService` (one YAML file per entity):
+
+- `catalog/sources/{id}.yaml` — one file per data source
+- `catalog/knowledge/{id}.yaml` — one file per source's knowledge entries
+- **Rationale**: Git diff clarity, glob-based listing, no concurrent write conflicts
+- **Migration from SPEC-1**: `catalog/sources.yaml` (single file) → `catalog/sources/`
+  (directory). Existing test `test_init_project_creates_catalog_sources_yaml` will be
+  updated to check for directory instead
+
+### Design Decision: User-Defined Source ID (Slug)
+
+Unlike `DesignService` which auto-generates IDs (`FP-H01`), catalog sources use
+user-defined slugs (e.g., `estat-population`, `bq-sales-data`):
+
+- **Rationale**: Data source names are inherently human-readable identifiers. Auto-generated
+  IDs would make MCP tool calls harder for Claude Code to construct
+- **Validation**: Must be non-empty string. Duplicate ID raises `ValueError`
+
+### Design Decision: FTS5 Index Strategy (Full Rebuild + Incremental)
+
+The FTS5 index uses a two-pronged strategy:
+
+**1. Full rebuild on startup** (per tech.md startup sequence):
+- `rebuild_index()` drops and recreates the FTS5 table on every startup
+- **Rationale**: YAML is source of truth. Full rebuild ensures consistency after
+  manual YAML edits or external changes between sessions
+- **Performance**: Acceptable for ≤100 sources (estimated &lt;2s based on benchmarks)
+
+**2. Incremental updates during a session**:
+- `add_source()` inserts the new source's metadata into FTS5 immediately after YAML write
+  (via `insert_document()`)
+- `update_source()` atomically replaces FTS5 rows for the source within a single
+  transaction (via `replace_source_documents()` — DELETE + INSERT in `BEGIN IMMEDIATE`)
+- **Rationale**: Users registering sources via `add_catalog_entry` MCP tool or
+  `/catalog-register` skill expect immediate searchability — waiting until next restart
+  would be a poor UX
+- **Crash safety**: YAML write happens first (source of truth), then FTS5 update.
+  If FTS5 update fails, YAML data is preserved and next `rebuild_index()` recovers
+  full consistency. FTS5 failure does not cause `add_source()` or `update_source()` to fail
+- **Manual YAML edits**: Changes made directly to YAML files (outside CatalogService)
+  are NOT reflected in FTS5 until the next restart when `rebuild_index()` runs
+
+## Components and Interfaces
+
+### `models/catalog.py`
+
+- **Purpose**: Pydantic data models for catalog entities — source types, column schema,
+  data sources, domain knowledge
+- **Interfaces**:
+  - `SourceType(StrEnum)`: `csv`, `api`, `sql`
+  - `KnowledgeCategory(StrEnum)`: `methodology`, `caution`, `definition`, `context`
+  - `KnowledgeImportance(StrEnum)`: `high`, `medium`, `low`
+  - `ColumnSchema(BaseModel)`: name, type, description + optional fields
+  - `DataSource(BaseModel)`: id, name, type, description, connection, schema_info, tags,
+    created_at, updated_at
+  - `DomainKnowledgeEntry(BaseModel)`: key, title, content, category, importance + metadata
+  - `DomainKnowledge(BaseModel)`: source_id, entries
+- **Dependencies**: `pydantic`, `models/common.py:now_jst`
+- **Reuses**: `now_jst()` for timestamp defaults (same as `AnalysisDesign`)
+
+### `storage/sqlite_store.py`
+
+- **Purpose**: SQLite FTS5 index management — build, search, and incrementally update
+  the full-text index
+- **Interfaces**:
+  - `build_index(db_path: Path, sources: list[dict], knowledge: list[dict]) -> None`
+    — DROP + CREATE FTS5 table, batch INSERT all documents (full rebuild)
+  - `search_index(db_path: Path, query: str, limit: int = 20) -> list[dict]`
+    — MATCH query with snippet() and rank ordering
+  - `insert_document(db_path: Path, doc_type: str, source_id: str, title: str, content: str) -> None`
+    — INSERT single row into existing FTS5 table (incremental add)
+  - `delete_source_documents(db_path: Path, source_id: str) -> None`
+    — DELETE all rows for a given source_id (used before re-insert on update)
+  - `replace_source_documents(db_path: Path, source_id: str, rows: list[dict]) -> None`
+    — Atomic DELETE + INSERT within a single transaction (used by `update_source()`)
+- **Connection management**: Per-call open/close (simple, no leak risk). All connections
+  set `PRAGMA journal_mode=WAL` and `PRAGMA busy_timeout=5000` on open
+- **Dependencies**: `sqlite3` (stdlib), `pathlib.Path`, `logging`
+- **Reuses**: None (new standalone module)
+- **Error handling**:
+  - FTS5 unavailable: catches `sqlite3.OperationalError` on CREATE, logs warning, returns
+  - Missing DB file: `search_index()` and incremental ops return silently (no crash)
+  - Incremental ops: catch `OperationalError` (e.g., `no such table`) and log warning —
+    YAML operations always succeed regardless of FTS5 state
+  - Query syntax error: wraps user query in double quotes (with `"` → `""` escaping),
+    catches OperationalError
+
+### `core/catalog.py`
+
+- **Purpose**: Business logic for catalog CRUD and search operations
+- **Interfaces**:
+  - `CatalogService(project_path: Path)` constructor — sets `_sources_dir`, `_knowledge_dir`,
+    `_db_path`
+  - `add_source(source: DataSource) -> DataSource` — persist + create empty knowledge + insert into FTS5
+  - `get_source(source_id: str) -> DataSource | None`
+  - `list_sources() -> list[DataSource]`
+  - `update_source(source_id: str, **fields) -> DataSource | None` — partial update + FTS5 atomic re-index via `replace_source_documents()`
+  - `get_schema(source_id: str) -> list[ColumnSchema] | None`
+  - `get_knowledge(source_id: str, category: KnowledgeCategory | None = None) -> DomainKnowledge | None`
+  - `search(query: str, source_type: SourceType | None = None, tags: list[str] | None = None) -> list[dict]`
+  - `rebuild_index() -> None`
+- **Dependencies**: `models/catalog.py`, `storage/yaml_store.py`, `storage/sqlite_store.py`
+- **Reuses**: `DesignService` patterns — glob listing, `model_copy(update=...)`, `read_yaml/write_yaml`
+
+### `server.py` (additions)
+
+- **Purpose**: 5 new MCP tools for catalog operations
+- **Interfaces**:
+  - `_catalog_service: CatalogService | None` — module-level reference
+  - `get_catalog_service() -> CatalogService` — RuntimeError guard
+  - `add_catalog_entry(source_id, name, type, description, connection, columns, tags?, primary_key?, row_count_estimate?) -> dict`
+  - `update_catalog_entry(source_id, name?, description?, connection?, columns?, tags?) -> dict`
+  - `get_table_schema(source_id) -> dict`
+  - `search_catalog(query, source_type?, tags?) -> dict`
+  - `get_domain_knowledge(source_id, category?) -> dict`
+- **Dependencies**: `core/catalog.py:CatalogService`, `models/catalog.py`
+- **Reuses**: Same error dict pattern as existing design tools
+
+### `storage/project.py` (modifications)
+
+- **Purpose**: Extended `init_project()` for catalog infrastructure
+- **Changes**:
+  - `_create_insight_dirs()`: Create `catalog/sources/` dir (replaces `sources.yaml` stub),
+    create `.sqlite/` dir
+  - `_copy_skills_template()`: Also copy `_skills/catalog-register/` to
+    `.claude/skills/catalog-register/`
+- **Reuses**: Existing `_copy_skills_template` pattern with `importlib.resources`
+
+### `cli.py` (modifications)
+
+- **Purpose**: Wire `CatalogService` and call `rebuild_index()` at startup
+- **Changes**:
+  - Import and instantiate `CatalogService(project_path)`
+  - Wire `server_module._catalog_service = catalog_service`
+  - Call `catalog_service.rebuild_index()` before `mcp.run()`
+
+## Data Models
+
+### DataSource YAML (`catalog/sources/{id}.yaml`)
+
+```yaml
+id: "estat-population"
+name: "e-Stat Population Census"
+type: "api"
+description: "Japanese population statistics from e-Stat"
+connection:
+  base_url: "https://api.e-stat.go.jp/rest/3.0"
+  provider: "e-stat"
+  table_id: "0003348423"
+  auth: "api_key"
+schema_info:
+  columns:
+    - name: "prefecture_code"
+      type: "string"
+      description: "JIS X 0401 prefecture code (01-47)"
+      nullable: false
+      examples: ["01", "13", "47"]
+    - name: "year"
+      type: "integer"
+      description: "Census year"
+      nullable: false
+      range: {min: 2000, max: 2024}
+    - name: "population"
+      type: "integer"
+      description: "Total population"
+      nullable: false
+      unit: "人"
+  primary_key: ["prefecture_code", "year"]
+  row_count_estimate: 2350
+tags: ["government", "population", "demographics"]
+created_at: "2026-02-24T10:00:00+09:00"
+updated_at: "2026-02-24T10:00:00+09:00"
+```
+
+### DomainKnowledge YAML (`catalog/knowledge/{id}.yaml`)
+
+```yaml
+source_id: "estat-population"
+entries:
+  - key: "methodology-change-2015"
+    title: "2015 Census Methodology Change"
+    content: |
+      Population counting methodology changed in 2015.
+      Direct comparison with pre-2015 data requires adjustment.
+    category: "caution"
+    importance: "high"
+    created_at: "2026-02-24T10:00:00+09:00"
+    source: "Reviewer domain expertise"
+    affects_columns: ["population", "household_count"]
+```
+
+### FTS5 Index Schema
+
+```sql
+CREATE VIRTUAL TABLE IF NOT EXISTS catalog_fts USING fts5(
+    doc_type,       -- 'source' or 'knowledge'
+    source_id,      -- references source YAML id
+    title,          -- source name or knowledge title
+    content,        -- description + column info, or knowledge content
+    tokenize='trigram'
+);
+```
+
+Each source is indexed as one row with `content` = concatenation of description +
+column names + column descriptions. Each knowledge entry is indexed as one row with
+`content` = entry content.
+
+### Connection Field Formats (by source type)
+
+```yaml
+# CSV
+connection:
+  file_path: "data/sales_2024.csv"
+  encoding: "utf-8"
+  delimiter: ","
+
+# API
+connection:
+  base_url: "https://api.e-stat.go.jp/rest/3.0"
+  provider: "e-stat"
+  table_id: "0003348423"
+  auth: "api_key"
+
+# SQL (BigQuery)
+connection:
+  provider: "bigquery"
+  project_id: "my-gcp-project"
+  dataset: "analytics"
+  table: "user_events"
+```
+
+## Error Handling
+
+### Error Scenarios
+
+1. **Duplicate source ID** — `add_source()` called with an `id` that already exists
+   - **Handling**: `CatalogService.add_source()` raises `ValueError`. `server.py` converts
+     to `{"error": "Source 'estat-pop' already exists"}`
+   - **User Impact**: Claude receives error dict and can inform the analyst to use
+     `update_catalog_entry` instead
+
+2. **Source not found** — `get_source()`, `get_schema()`, `get_knowledge()`, `update_source()`
+   called with nonexistent `source_id`
+   - **Handling**: Service returns `None`. Server converts to `{"error": "Source 'xyz' not found"}`
+   - **User Impact**: Claude receives error dict and can suggest correct source ID
+
+3. **Invalid source type** — `add_catalog_entry()` called with `type="parquet"`
+   - **Handling**: Pydantic validation fails on `SourceType`. Server catches `ValueError`
+     and returns `{"error": ...}`
+   - **User Impact**: Claude informed of valid types (csv, api, sql)
+
+4. **Invalid knowledge category** — `get_domain_knowledge()` called with invalid `category`
+   - **Handling**: `KnowledgeCategory(value)` raises `ValueError`. Server returns
+     `{"error": "Invalid category 'xyz'"}`
+   - **User Impact**: Claude informed of valid categories
+
+5. **FTS5 extension unavailable** — Python's sqlite3 compiled without FTS5 support
+   - **Handling**: `build_index()` catches `sqlite3.OperationalError` on CREATE VIRTUAL TABLE,
+     logs warning via `logging.warning()`. `search_index()` returns empty list
+   - **User Impact**: Search returns no results. All other catalog operations work normally.
+     Warning appears in logs for debugging
+
+6. **FTS5 query syntax error** — Malformed search query
+   - **Handling**: User queries are sanitized: `"` escaped to `""`, then wrapped in
+     double quotes (`"sanitized query"`) before MATCH. Empty queries return empty results
+     immediately. All queries use parameterized binding (`MATCH ?`). `search_index()`
+     catches any remaining `OperationalError` and returns empty list
+   - **User Impact**: Search returns no results rather than crashing
+
+7. **CatalogService not initialized** — MCP tool called before `cli.py` wiring
+   - **Handling**: `get_catalog_service()` raises `RuntimeError` (same pattern as `get_service()`)
+   - **User Impact**: MCP protocol returns error. Only occurs in test/dev scenarios
+
+## Testing Strategy
+
+### Unit Testing
+
+| File | Coverage Target |
+|------|----------------|
+| `tests/test_catalog_models.py` | `models/catalog.py` — 10 tests |
+| `tests/test_sqlite_store.py` | `storage/sqlite_store.py` — 15 tests |
+| `tests/test_catalog.py` | `core/catalog.py` — 26 tests |
+| `tests/test_server.py` (extended) | server.py catalog tools — 15 tests |
+| `tests/test_storage.py` (extended) | project.py changes — 3 tests |
+
+**test_catalog_models.py** (models validation):
+- SourceType enum values and rejection of invalid values
+- ColumnSchema required/optional field defaults
+- DataSource instantiation, timestamp defaults, JSON round-trip
+- KnowledgeCategory/Importance enum values
+- DomainKnowledgeEntry and DomainKnowledge container
+
+**test_sqlite_store.py** (FTS5 operations):
+- `build_index()`: DB file creation, empty data, source indexing, knowledge indexing, rebuild
+- `search_index()`: matching results, no match, ranking, snippets, missing DB, FTS5 unavailable
+- `insert_document()`: incremental add is immediately searchable
+- `delete_source_documents()`: removes all rows for a source_id
+- `replace_source_documents()`: atomic DELETE + INSERT in transaction, rollback on failure
+- Incremental ops with missing FTS5 table: graceful no-op with warning log
+
+**test_catalog.py** (CatalogService CRUD + search):
+- `add_source()`: file creation, knowledge file creation, schema persistence, duplicate error, FTS5 incremental insert
+- `get_source()`, `list_sources()`, `get_schema()`, `get_knowledge()`: retrieval and filtering
+- `update_source()`: partial update, updated_at refresh, persistence, missing source, FTS5 re-index
+- `search()`: FTS5 results, source_type/tags filtering, graceful degradation
+- `rebuild_index()`: FTS5 DB creation
+
+### Integration Testing
+
+- Full round-trip test in `tests/test_integration.py`:
+  `init_project()` → `add_source()` → `get_source()` → `get_schema()` → `search()`
+  (immediately searchable via incremental FTS5 update) → `get_knowledge()`
+  — all with real YAML files and SQLite DB
+- `init_project()` creates `catalog/sources/` dir, `.sqlite/` dir, copies catalog-register skill
+- Existing SPEC-1/1a tests continue to pass (regression check)
+
+### End-to-End Testing
+
+Full MCP protocol E2E testing remains out of scope (same as SPEC-1).
+Integration tests cover the full business logic stack.
+
+### Acceptance Criteria × Test Case Mapping
+
+| AC | Content (Summary) | Test Cases | File |
+|----|-------------------|------------|------|
+| R1-AC1 | SourceType.csv stored correctly | `test_source_type_enum_has_csv_api_sql` | `test_catalog_models.py` |
+| R1-AC2 | now_jst() default timestamps | `test_data_source_timestamps_default_to_jst` | `test_catalog_models.py` |
+| R1-AC3 | ColumnSchema optional defaults | `test_column_schema_optional_fields_default_to_none` | `test_catalog_models.py` |
+| R1-AC4 | JSON round-trip | `test_data_source_model_dump_json_round_trip` | `test_catalog_models.py` |
+| R1-AC5 | DomainKnowledge empty entries | `test_domain_knowledge_container_with_empty_entries` | `test_catalog_models.py` |
+| R1-AC6 | Invalid SourceType rejected | `test_source_type_rejects_invalid_value` | `test_catalog_models.py` |
+| R2-AC1 | add_source creates files | `test_add_source_creates_source_yaml_file`, `test_add_source_creates_empty_knowledge_file` | `test_catalog.py` |
+| R2-AC2 | Duplicate ID raises ValueError | `test_add_source_duplicate_id_raises_value_error` | `test_catalog.py` |
+| R2-AC3 | get_source returns correct data | `test_get_source_returns_correct_source` | `test_catalog.py` |
+| R2-AC4 | get_source returns None for missing | `test_get_source_returns_none_for_missing_id` | `test_catalog.py` |
+| R2-AC5 | list_sources returns all | `test_list_sources_returns_all` | `test_catalog.py` |
+| R2-AC6 | update_source patches correctly | `test_update_source_patches_name_field`, `test_update_source_refreshes_updated_at` | `test_catalog.py` |
+| R2-AC7 | update_source None for missing | `test_update_source_returns_none_for_missing_id` | `test_catalog.py` |
+| R2-AC8 | get_knowledge returns entries | `test_get_knowledge_returns_domain_knowledge` | `test_catalog.py` |
+| R2-AC9 | get_knowledge category filter | `test_get_knowledge_filters_by_category` | `test_catalog.py` |
+| R3-AC1 | rebuild creates FTS DB | `test_rebuild_index_creates_fts_db` | `test_catalog.py` |
+| R3-AC2 | search returns matches | `test_search_returns_matching_results` | `test_catalog.py` |
+| R3-AC3 | search with type filter | `test_search_filters_by_source_type` | `test_catalog.py` |
+| R3-AC4 | search empty for no match | `test_search_index_returns_empty_for_no_match` | `test_sqlite_store.py` |
+| R3-AC5 | rebuild replaces old index | `test_build_index_replaces_old_index_on_rebuild` | `test_sqlite_store.py` |
+| R3-AC6 | FTS5 unavailable graceful | `test_build_index_handles_fts5_unavailable` | `test_sqlite_store.py` |
+| R4-AC1 | add_catalog_entry success | `test_add_catalog_entry_returns_success_dict` | `test_server.py` |
+| R4-AC2 | add_catalog_entry duplicate | `test_add_catalog_entry_duplicate_returns_error_dict` | `test_server.py` |
+| R4-AC3 | add_catalog_entry invalid type | `test_add_catalog_entry_invalid_type_returns_error_dict` | `test_server.py` |
+| R4-AC4 | update_catalog_entry success | `test_update_catalog_entry_patches_fields` | `test_server.py` |
+| R4-AC5 | update_catalog_entry missing | `test_update_catalog_entry_missing_returns_error_dict` | `test_server.py` |
+| R4-AC6 | get_table_schema success | `test_get_table_schema_returns_columns` | `test_server.py` |
+| R4-AC7 | get_table_schema missing | `test_get_table_schema_missing_returns_error_dict` | `test_server.py` |
+| R4-AC8 | search_catalog returns results | `test_search_catalog_returns_results_dict` | `test_server.py` |
+| R4-AC9 | get_domain_knowledge success | `test_get_domain_knowledge_returns_entries` | `test_server.py` |
+| R4-AC10 | get_domain_knowledge invalid | `test_get_domain_knowledge_invalid_category_returns_error` | `test_server.py` |
+| R5-AC1 | CLI wires CatalogService | `test_catalog_full_round_trip` | `test_integration.py` |
+| R5-AC2 | init creates sources dir | `test_init_project_creates_sources_directory` | `test_storage.py` |
+| R5-AC3 | init creates .sqlite dir | `test_init_project_creates_sqlite_dir` | `test_storage.py` |
+| R5-AC4 | init copies catalog-register | `test_init_project_copies_catalog_register_skill` | `test_storage.py` |
+| R6-AC1 | Skill guides registration | Manual verification | — |
+| R6-AC2 | Skill has valid frontmatter | `test_init_project_copies_catalog_register_skill` | `test_storage.py` |

--- a/.spec-workflow/specs/SPEC-2/requirements.md
+++ b/.spec-workflow/specs/SPEC-2/requirements.md
@@ -1,0 +1,311 @@
+# SPEC-2: data-catalog — Requirements
+
+> **Spec ID**: SPEC-2
+> **Feature Name**: data-catalog
+> **Status**: pending_approval
+> **Created**: 2026-02-24
+> **Depends On**: SPEC-1 (core-foundation), SPEC-1a (hypothesis-enrichment)
+
+---
+
+## Introduction
+
+SPEC-2 adds a data catalog to insight-blueprint so that data scientists can register,
+search, and reference data source definitions (name, type, connection info, column schema)
+and domain knowledge through MCP tools. Sources and knowledge are persisted as per-file
+YAML (one file per source), while SQLite FTS5 provides fast full-text search across both
+source metadata and knowledge entries. The catalog gives Claude Code the context it needs
+to generate accurate queries and avoid common data pitfalls during EDA sessions.
+
+## Alignment with Product Vision
+
+This spec directly enables three core product goals defined in `product.md`:
+
+- **Communicating data access rules and domain knowledge to AI**: The catalog MCP tools
+  (`search_catalog`, `get_table_schema`, `get_domain_knowledge`) give Claude Code structured
+  access to column schemas, connection details, and domain cautions — eliminating the burden
+  of manually explaining data structure to the AI.
+- **Accumulating domain knowledge for continuous reuse**: Per-source knowledge files
+  (`catalog/knowledge/{source_id}.yaml`) store methodology notes, cautions, and definitions
+  that persist across sessions and are searchable via FTS5.
+- **Spec Roadmap progression**: SPEC-2 provides the data catalog layer that SPEC-3
+  (review-workflow) extends with knowledge write tools and that SPEC-4 (webui-dashboard)
+  surfaces in the Catalog tab.
+
+## Requirements
+
+### Requirement 1: Catalog Data Models
+
+**User Story:** As a data scientist, I want the data sources I use in my analysis
+(CSV files, API endpoints, SQL tables) to have structured definitions with column-level
+schema information, so that Claude Code can understand my data and generate correct queries.
+
+**FR-1: Source and Schema Models**
+- `SourceType` enum with three values: `csv`, `api`, `sql`
+- `ColumnSchema` model with required fields: `name: str`, `type: str`, `description: str`
+  and optional fields: `nullable: bool` (default `True`), `examples: list[str] | None`,
+  `range: dict | None`, `unit: str | None`
+- `DataSource` model with fields:
+  - `id: str` — user-defined slug (e.g., `estat-population`)
+  - `name: str` — human-readable display name
+  - `type: SourceType` — csv/api/sql
+  - `description: str`
+  - `connection: dict` — untyped dict (structure varies by source type)
+  - `schema_info: dict` — contains `columns: list[ColumnSchema]`,
+    optional `primary_key: list[str]`, optional `row_count_estimate: int`
+  - `tags: list[str]` (default empty list)
+  - `created_at: datetime` (default `now_jst()`)
+  - `updated_at: datetime` (default `now_jst()`)
+
+**FR-2: Domain Knowledge Models**
+- `KnowledgeCategory` enum: `methodology`, `caution`, `definition`, `context`
+- `KnowledgeImportance` enum: `high`, `medium`, `low`
+- `DomainKnowledgeEntry` model with fields:
+  - `key: str` — unique key within source (e.g., `methodology-change-2015`)
+  - `title: str`
+  - `content: str`
+  - `category: KnowledgeCategory`
+  - `importance: KnowledgeImportance` (default `medium`)
+  - `created_at: datetime` (default `now_jst()`)
+  - `source: str | None` — origin of knowledge (e.g., "Reviewer domain expertise")
+  - `affects_columns: list[str]` (default empty list)
+- `DomainKnowledge` container model with fields:
+  - `source_id: str`
+  - `entries: list[DomainKnowledgeEntry]` (default empty list)
+
+#### Acceptance Criteria
+
+1. WHEN a `DataSource` is created with `type="csv"` THEN `SourceType.csv` is stored and serialized as `"csv"` in YAML
+2. WHEN a `DataSource` is created without `created_at` THEN `now_jst()` is used as default
+3. WHEN a `ColumnSchema` is created with only required fields THEN optional fields default to `None` (except `nullable` which defaults to `True`)
+4. WHEN a `DataSource` is serialized via `model_dump(mode="json")` and deserialized back THEN the round-trip produces an equivalent model
+5. WHEN a `DomainKnowledge` is created without entries THEN `entries` defaults to an empty list
+6. WHEN an invalid `SourceType` value (e.g., `"parquet"`) is used THEN a validation error is raised
+
+### Requirement 2: Catalog CRUD Operations
+
+**User Story:** As a data scientist using Claude Code, I want to register data sources
+to the catalog and retrieve them by ID, so that Claude can reference my data definitions
+when designing analyses.
+
+**FR-3: Add Source**
+- `add_source()` accepts a `DataSource` model (or equivalent parameters) and persists it
+  to `catalog/sources/{id}.yaml`
+- On successful add, creates an empty knowledge file at `catalog/knowledge/{id}.yaml`
+  with `source_id` and empty `entries` list
+- On successful add, inserts the source into the FTS5 index so it is immediately searchable
+- If a source with the same `id` already exists, raises `ValueError`
+
+**FR-4: Get Source and List Sources**
+- `get_source(source_id)` reads `catalog/sources/{source_id}.yaml` and returns a
+  `DataSource` model, or `None` if not found
+- `list_sources()` globs `catalog/sources/*.yaml` and returns all sources as a list
+- `get_schema(source_id)` returns the `columns` list from the source's `schema_info`,
+  or `None` if source not found
+
+**FR-5: Update Source**
+- `update_source(source_id, **fields)` partially updates a source using `model_copy(update=...)`
+- Automatically refreshes `updated_at` to `now_jst()`
+- Returns updated `DataSource`, or `None` if source not found
+- Persists changes to the same `sources/{id}.yaml` file
+- Updates the FTS5 index (delete old rows + re-insert) so changes are immediately searchable
+
+**FR-6: Get Domain Knowledge**
+- `get_knowledge(source_id, category?)` reads `catalog/knowledge/{source_id}.yaml`
+  and returns `DomainKnowledge`
+- Optional `category` parameter filters entries by `KnowledgeCategory`
+- Returns `None` if source knowledge file not found
+
+#### Acceptance Criteria
+
+1. WHEN `add_source()` is called with a new source THEN `catalog/sources/{id}.yaml` is created AND `catalog/knowledge/{id}.yaml` is created with empty entries
+2. WHEN `add_source()` is called with a duplicate `id` THEN `ValueError` is raised
+3. WHEN `get_source("estat-pop")` is called after adding a source with that id THEN the correct `DataSource` is returned
+4. WHEN `get_source("nonexistent")` is called THEN `None` is returned
+5. WHEN `list_sources()` is called after adding 3 sources THEN a list of 3 `DataSource` models is returned
+6. WHEN `update_source("estat-pop", name="New Name")` is called THEN only `name` and `updated_at` are changed
+7. WHEN `update_source("nonexistent", ...)` is called THEN `None` is returned
+8. WHEN `get_knowledge("estat-pop")` is called THEN `DomainKnowledge` is returned (empty entries if no knowledge added)
+9. WHEN `get_knowledge("estat-pop", category="caution")` is called THEN only entries with `category == "caution"` are returned
+
+### Requirement 3: Full-Text Search
+
+**User Story:** As a data scientist, I want to search across all data sources and domain
+knowledge by keyword, so that I can quickly find relevant data and cautions for my analysis.
+
+**FR-7: FTS5 Index Build and Incremental Update**
+- `build_index(db_path, sources, knowledge_entries)` creates a SQLite FTS5 virtual table
+- Indexes source metadata (name, description, column descriptions) and knowledge entries
+  (title, content)
+- Each indexed row includes: `doc_type` (source/knowledge), `source_id`, `title`, `content`
+- On rebuild, drops existing table and recreates (full rebuild strategy per tech.md)
+- Incremental operations: `insert_document()` adds a single row, `delete_source_documents()`
+  removes all rows for a source_id — used by `add_source()` and `update_source()` to keep
+  the FTS5 index up-to-date during a session without requiring a full rebuild
+
+**FR-8: FTS5 Search**
+- `search_index(db_path, query)` executes a MATCH query against the FTS5 table
+- Returns results ranked by relevance (FTS5 built-in ranking)
+- Each result includes: `source_id`, `doc_type`, `title`, `snippet` (via FTS5 `snippet()`)
+- Returns empty list if database file does not exist or query matches nothing
+
+**FR-9: Catalog Search**
+- `search(query, source_type?, tags?)` combines FTS5 results with optional Python-side
+  post-filtering by `source_type` and `tags`
+- `rebuild_index()` collects all sources and knowledge entries and calls `build_index()`
+
+#### Acceptance Criteria
+
+1. WHEN `rebuild_index()` is called after adding sources THEN a `.sqlite/catalog_fts.db` file is created
+2. WHEN `search("population")` is called immediately after `add_source()` (without `rebuild_index()`) THEN at least one result is returned with a snippet (incremental FTS5 update)
+3. WHEN `search("population", source_type="csv")` is called but only API sources contain "population" THEN empty results are returned
+4. WHEN `search("nonexistent-keyword")` is called THEN empty results are returned
+5. WHEN `rebuild_index()` is called twice THEN the second call replaces the old index (no duplicate entries)
+6. WHEN FTS5 extension is unavailable THEN `build_index()` logs a warning and subsequent searches return empty results
+
+### Requirement 4: MCP Tools
+
+**User Story:** As a data scientist using Claude Code, I want Claude to register, search,
+and query my data catalog through MCP tools, so that data context is always available
+during my analysis sessions.
+
+**FR-10: add_catalog_entry Tool**
+- Accepts: `source_id`, `name`, `type` (csv/api/sql), `description`, `connection` (dict),
+  `columns` (list of column dicts), optional `tags`, optional `primary_key`,
+  optional `row_count_estimate`
+- Returns: `{source_id, name, type, message}` on success, `{error}` on failure
+- Maps to `CatalogService.add_source()`
+
+**FR-11: update_catalog_entry Tool**
+- Accepts: `source_id`, optional fields to update (`name`, `description`, `connection`,
+  `columns`, `tags`)
+- Returns: full source dict on success, `{error}` on failure
+- Maps to `CatalogService.update_source()`
+
+**FR-12: get_table_schema Tool**
+- Accepts: `source_id`
+- Returns: `{source_id, columns: [...], primary_key, row_count_estimate}` on success,
+  `{error}` if source not found
+- Maps to `CatalogService.get_source()` with schema extraction
+
+**FR-13: search_catalog Tool**
+- Accepts: `query`, optional `source_type`, optional `tags` (comma-separated string)
+- Returns: `{results: [...], count}` with each result containing `source_id`, `doc_type`,
+  `title`, `snippet`
+- Maps to `CatalogService.search()`
+
+**FR-14: get_domain_knowledge Tool**
+- Accepts: `source_id`, optional `category`
+- Returns: `{source_id, entries: [...], count}` on success, `{error}` if not found
+- Invalid `category` value returns `{error}` (not exception)
+- Maps to `CatalogService.get_knowledge()`
+
+#### Acceptance Criteria
+
+1. WHEN `add_catalog_entry()` is called with valid parameters THEN `{source_id, name, type, message}` is returned
+2. WHEN `add_catalog_entry()` is called with duplicate `source_id` THEN `{error}` dict is returned
+3. WHEN `add_catalog_entry()` is called with invalid type `"parquet"` THEN `{error}` dict is returned
+4. WHEN `update_catalog_entry()` is called with valid `source_id` THEN updated source dict is returned
+5. WHEN `update_catalog_entry()` is called with nonexistent `source_id` THEN `{error}` dict is returned
+6. WHEN `get_table_schema()` is called with existing source THEN column list is returned
+7. WHEN `get_table_schema()` is called with nonexistent source THEN `{error}` dict is returned
+8. WHEN `search_catalog(query="population")` is called THEN matching results with snippets are returned
+9. WHEN `get_domain_knowledge(source_id="estat-pop")` is called THEN entries are returned
+10. WHEN `get_domain_knowledge(source_id="estat-pop", category="invalid")` is called THEN `{error}` dict is returned
+
+### Requirement 5: CLI Wiring and Project Initialization
+
+**User Story:** As a data scientist, I want the catalog to be ready immediately when
+I start insight-blueprint, with FTS5 index built and catalog-register skill available,
+so that I can start searching data sources right away.
+
+**FR-15: CLI Startup Integration**
+- `cli.py` instantiates `CatalogService` and wires it to `server._catalog_service`
+- Calls `catalog_service.rebuild_index()` before `mcp.run()` so FTS5 is ready at startup
+
+**FR-16: Project Initialization Updates**
+- `init_project()` creates `catalog/sources/` directory (replacing the old `catalog/sources.yaml` stub)
+- `init_project()` creates `.insight/.sqlite/` directory for FTS5 database files
+- `init_project()` copies bundled `catalog-register` skill to `.claude/skills/catalog-register/`
+  (if not already present)
+
+#### Acceptance Criteria
+
+1. WHEN `uvx insight-blueprint --project /path` is run THEN `CatalogService` is initialized and all 5 catalog MCP tools are available
+2. WHEN `init_project()` is called THEN `.insight/catalog/sources/` directory is created (not `sources.yaml` file)
+3. WHEN `init_project()` is called THEN `.insight/.sqlite/` directory is created
+4. WHEN `init_project()` is called THEN `.claude/skills/catalog-register/SKILL.md` is copied
+5. WHEN startup completes THEN `rebuild_index()` has been called and FTS5 is searchable
+
+### Requirement 6: Catalog Register Skill
+
+**User Story:** As a data scientist, I want a `/catalog-register` Claude Code skill that
+automatically explores my CSV/API/SQL data sources and registers them to the catalog,
+so that I don't have to manually construct the catalog entry.
+
+**FR-17: Bundled Catalog Register Skill**
+- A SKILL.md file at `_skills/catalog-register/SKILL.md` with valid YAML frontmatter
+- The skill guides Claude Code through:
+  1. Identifying the source type (CSV/API/SQL)
+  2. Exploring the data structure (read CSV headers, query API metadata, query INFORMATION_SCHEMA)
+  3. Building the `DataSource` model with column schema
+  4. Calling `add_catalog_entry()` MCP tool to register
+- Supports all three source types: CSV, API (e-Stat pattern), SQL (BigQuery pattern)
+
+#### Acceptance Criteria
+
+1. WHEN `/catalog-register` skill is invoked THEN Claude Code is guided through source exploration and registration
+2. WHEN the skill file is copied to `.claude/skills/` THEN it contains valid YAML frontmatter with `name`, `description`, and `disable-model-invocation: true`
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+
+- **Single Responsibility Principle**: `models/catalog.py` = data models only,
+  `storage/sqlite_store.py` = FTS5 index only, `core/catalog.py` = business logic only
+- **Three-Layer Separation**: MCP tools (server.py) delegate to `CatalogService` (core/catalog.py),
+  which delegates to `yaml_store.py` and `sqlite_store.py`; no cross-layer skipping
+- **Pattern Reuse**: `CatalogService` follows the same structure as `DesignService`
+  (constructor with project_path, glob-based listing, model_copy for updates)
+- **Type Annotations Required**: All functions have complete type annotations; `ty check` passes
+- **Code Quality**: `ruff check` passes; `pytest` coverage for `core/catalog.py` and
+  `storage/sqlite_store.py` is 80% or higher
+
+### Performance
+
+- `add_source()` completes within 100ms (two YAML writes + FTS5 incremental insert)
+- `search()` completes within 200ms for up to 500 indexed documents
+- `rebuild_index()` completes within 2 seconds for up to 100 sources
+- `get_source()` completes within 50ms (single YAML read)
+
+### Security
+
+- No hardcoded secrets, API keys, or credentials in source code
+- FTS5 queries are parameterized (no string interpolation in SQL)
+- User-provided search queries are wrapped in double quotes to prevent FTS5 syntax injection
+- Error messages do not expose internal file paths or stack traces to MCP clients
+
+### Reliability
+
+- FTS5 extension unavailable: `build_index()` catches `OperationalError`, logs a warning,
+  and subsequent searches return empty results (graceful degradation)
+- FTS5 query syntax error: `search_index()` catches `OperationalError` and returns empty results
+- Missing database file: `search_index()` returns empty results (no crash)
+- All YAML writes remain atomic (`tempfile.mkstemp()` + `os.replace()`)
+- Existing SPEC-1/SPEC-1a tests continue to pass (no regressions)
+
+### Usability
+
+- MCP tool docstrings clearly describe parameters and return formats
+- Search results include snippets so Claude Code can show relevant context to the user
+- `add_catalog_entry` accepts flat parameters (not nested model) for ease of MCP tool calling
+- Error dicts include actionable messages (e.g., "Source 'xyz' already exists")
+
+## Out of Scope
+
+- Parquet and Excel source types (future extension)
+- Delete catalog entry tool (not needed for v1 workflow)
+- Knowledge write tools (SPEC-3: review-workflow will add these)
+- Data preview / data exploration through MCP (the `/catalog-register` skill does exploration,
+  but via Claude Code's own tools, not MCP)
+- WebUI catalog tab (SPEC-4)

--- a/.spec-workflow/specs/SPEC-2/tasks.md
+++ b/.spec-workflow/specs/SPEC-2/tasks.md
@@ -1,0 +1,211 @@
+# Tasks: SPEC-2 data-catalog
+
+## Dependency Graph
+
+```
+1.1 (Models) ─────┬──→ 1.2 (FTS5 Store)
+                   │
+                   └──→ 2.1 (Service: add/get)
+                              │
+                              └──→ 2.2 (Service: update/search)
+                                        │
+                                        ├──→ 3.1 (MCP: add/update/get)
+                                        │
+                                        └──→ 3.2 (MCP: search/knowledge)
+                                                   │
+                                                   └──→ 4.1 (CLI wiring + integration)
+                                                              │
+                                                              └──→ 4.2 (Skill: /catalog-register)
+```
+
+---
+
+- [x] 1.1 Implement Pydantic models for data catalog
+  - File: src/insight_blueprint/models/catalog.py, src/insight_blueprint/models/__init__.py, tests/test_catalog_models.py
+  - `SourceType(StrEnum)` を作成: csv, api, sql
+  - `KnowledgeCategory(StrEnum)` を作成: methodology, caution, definition, context
+  - `KnowledgeImportance(StrEnum)` を作成: high, medium, low
+  - `ColumnSchema(BaseModel)` を作成: name/type/description (必須) + nullable/examples/range/unit (オプション)
+  - `DataSource(BaseModel)` を作成: id/name/type/description/connection/schema_info/tags/created_at/updated_at
+  - `DomainKnowledgeEntry(BaseModel)` を作成: key/title/content/category/importance/created_at/source/affects_columns
+  - `DomainKnowledge(BaseModel)` を作成: source_id/entries (default empty list)
+  - `models/__init__.py` に catalog models を re-export する
+  - Purpose: storage・core・MCP 層で共有する data catalog 型を定義する
+  - _Leverage: src/insight_blueprint/models/common.py (now_jst), src/insight_blueprint/models/design.py (StrEnum/BaseModel pattern)_
+  - _Requirements: FR-1, FR-2_
+  - **完了基準**:
+    1. `tests/test_catalog_models.py` の 10 テストケースすべてが pass する
+    2. `from insight_blueprint.models import DataSource, SourceType, ColumnSchema` が動作する
+    3. `poe lint` と `poe typecheck` が pass する
+  - **確認手続き**: `poe test -- tests/test_catalog_models.py -v` で全テスト pass を確認。`poe lint && poe typecheck` で品質チェック pass を確認
+  - _Prompt: Implement the task for spec SPEC-2, first run spec-workflow-guide to get the workflow guide then implement the task: Role: Python developer specializing in Pydantic v2 data modeling | Task: Implement catalog Pydantic models per FR-1 and FR-2 — SourceType(StrEnum), KnowledgeCategory(StrEnum), KnowledgeImportance(StrEnum), ColumnSchema, DataSource, DomainKnowledgeEntry, DomainKnowledge; use now_jst() from models/common.py for timestamp defaults; follow DesignStatus/AnalysisDesign pattern from models/design.py | Restrictions: Use Pydantic v2 (BaseModel, Field); all fields must have type annotations; StrEnum for enums (not Enum); connection field is untyped dict; schema_info is dict with columns key; DataSource must use model_config = ConfigDict(extra="ignore") for schema evolution | Success: 10 tests pass in test_catalog_models.py covering enum values, optional defaults, timestamp defaults, JSON round-trip, container defaults, invalid enum rejection; re-export from models/__init__.py works; poe lint and poe typecheck pass | After completing implementation and tests: (1) mark task [-] to [x] in tasks.md (2) log implementation with log-implementation tool_
+
+- [x] 1.2 Implement SQLite FTS5 storage layer
+  - File: src/insight_blueprint/storage/sqlite_store.py, tests/test_sqlite_store.py
+  - `build_index(db_path, sources, knowledge)` を実装: DROP + CREATE VIRTUAL TABLE (trigram tokenizer) + executemany batch INSERT
+  - `search_index(db_path, query, limit=20)` を実装: MATCH クエリ + snippet() + rank ordering。クエリは `"` → `""` エスケープ + ダブルクオートで囲む。空クエリは即座に空リスト返却
+  - `insert_document(db_path, doc_type, source_id, title, content)` を実装: 単一行 INSERT（増分追加用）
+  - `delete_source_documents(db_path, source_id)` を実装: source_id の全行 DELETE
+  - `replace_source_documents(db_path, source_id, rows)` を実装: BEGIN IMMEDIATE トランザクション内で DELETE + INSERT を原子的に実行
+  - 全接続に `PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;` を設定
+  - FTS5 unavailable 時: `OperationalError` を catch して `logging.warning()` → 空リスト返却（graceful degradation）
+  - Purpose: FTS5 全文検索インデックスの構築・検索・増分更新を提供する
+  - _Leverage: なし（新規 standalone モジュール）_
+  - _Requirements: FR-7, FR-8_
+  - **完了基準**:
+    1. `tests/test_sqlite_store.py` の 15 テストケースすべてが pass する
+    2. `build_index` → `search_index` のラウンドトリップで日本語・英語両方の検索が動作する
+    3. `insert_document` 後に即座に `search_index` で検索可能
+    4. `replace_source_documents` がトランザクション内で原子的に動作する
+    5. FTS5 unavailable 時に例外が発生せず warning ログが出力される
+    6. `poe lint` と `poe typecheck` が pass する
+  - **確認手続き**: `poe test -- tests/test_sqlite_store.py -v` で全テスト pass を確認。`poe lint && poe typecheck` で品質チェック pass を確認
+  - _Prompt: Implement the task for spec SPEC-2, first run spec-workflow-guide to get the workflow guide then implement the task: Role: Python developer specializing in SQLite FTS5 and database operations | Task: Implement sqlite_store.py with build_index (full rebuild), search_index (MATCH + snippet + rank), insert_document (incremental add), delete_source_documents, and replace_source_documents (atomic DELETE+INSERT in BEGIN IMMEDIATE transaction) per FR-7 and FR-8; use trigram tokenizer for Japanese+English mixed content; set PRAGMA journal_mode=WAL and busy_timeout=5000 on all connections | Restrictions: No Pydantic dependency — receive plain dicts; all functions accept db_path as Path; parameterized queries only (no string interpolation in SQL); escape " to "" in user queries then wrap in double quotes; empty query returns [] immediately; catch OperationalError for FTS5 unavailable and log warning; per-call open/close for connections | Success: 15 tests pass covering build (file creation, empty data, source indexing, knowledge indexing, rebuild), search (matching, no match, ranking, snippets, missing DB), insert_document (immediate searchability), delete_source_documents, replace_source_documents (atomic), incremental ops with missing table (graceful no-op), FTS5 unavailable graceful degradation; poe lint and poe typecheck pass | After completing implementation and tests: (1) mark task [-] to [x] in tasks.md (2) log implementation with log-implementation tool_
+
+- [x] 2.1 Implement CatalogService: add, get, list, get_schema, get_knowledge
+  - File: src/insight_blueprint/core/catalog.py, tests/test_catalog.py, src/insight_blueprint/storage/project.py, tests/test_storage.py
+  - `CatalogService(project_path)` constructor を実装: `_sources_dir`, `_knowledge_dir`, `_db_path` を設定
+  - `add_source(source: DataSource)` を実装: `sources/{id}.yaml` 作成 + `knowledge/{id}.yaml` 作成（空 entries）+ FTS5 増分 INSERT
+  - `get_source(source_id)` を実装: 単一ファイル読込 → DataSource | None
+  - `list_sources()` を実装: glob `sources/*.yaml` → list[DataSource]（DesignService.list_designs パターン）
+  - `get_schema(source_id)` を実装: source の columns リスト → list[ColumnSchema] | None
+  - `get_knowledge(source_id, category?)` を実装: knowledge ファイル読込 + category フィルタ → DomainKnowledge | None
+  - `init_project()` を修正: `catalog/sources.yaml` → `catalog/sources/` ディレクトリに変更 + `.sqlite/` ディレクトリ作成
+  - 既存テスト `test_init_project_creates_catalog_sources_yaml` を `test_init_project_creates_sources_directory` に修正
+  - Purpose: カタログ CRUD の基本操作（add/get/list/schema/knowledge）を提供する
+  - _Leverage: src/insight_blueprint/core/designs.py (glob listing, read_yaml/write_yaml pattern), src/insight_blueprint/storage/yaml_store.py, src/insight_blueprint/storage/sqlite_store.py_
+  - _Requirements: FR-3, FR-4, FR-5 (get_knowledge), FR-6 (get_knowledge filter), FR-16 (init changes)_
+  - **完了基準**:
+    1. `tests/test_catalog.py` の add/get/list/schema/knowledge テスト（14件）すべてが pass する
+    2. `tests/test_storage.py` の既存テストが修正後も全 pass する（回帰なし）
+    3. `add_source` が YAML + knowledge ファイル + FTS5 の 3 つを作成する
+    4. duplicate ID で `ValueError` が発生する
+    5. `get_knowledge(category="caution")` でカテゴリフィルタが正しく動作する
+    6. `poe all` が pass する（既存 SPEC-1/1a テストも含めて全 pass）
+  - **確認手続き**: `poe test -- tests/test_catalog.py tests/test_storage.py -v` で全テスト pass を確認。`poe all` で全体の回帰テスト + lint + typecheck pass を確認
+  - _Prompt: Implement the task for spec SPEC-2, first run spec-workflow-guide to get the workflow guide then implement the task: Role: Python developer specializing in service layer architecture | Task: Implement CatalogService with add_source, get_source, list_sources, get_schema, get_knowledge per FR-3/FR-4/FR-5/FR-6; follow DesignService pattern from core/designs.py; add_source creates sources/{id}.yaml + knowledge/{id}.yaml + FTS5 insert; modify init_project to create catalog/sources/ dir (replacing sources.yaml stub) and .sqlite/ dir; fix existing test | Restrictions: Use read_yaml/write_yaml from yaml_store.py; duplicate source_id raises ValueError; get_source returns None for missing; get_knowledge with category param filters entries; FTS5 insert_document failure must not cause add_source to fail (catch and warn); do NOT modify existing designs/ tests | Success: 14 tests pass in test_catalog.py; test_storage.py existing tests pass with directory change; add_source round-trip works; duplicate raises ValueError; get_knowledge filters by category; poe all passes (all existing + new tests green) | After completing implementation and tests: (1) mark task [-] to [x] in tasks.md (2) log implementation with log-implementation tool_
+
+- [x] 2.2 Implement CatalogService: update_source, search, rebuild_index
+  - File: src/insight_blueprint/core/catalog.py (拡張), tests/test_catalog.py (拡張)
+  - `update_source(source_id, **fields)` を実装: `model_copy(update=...)` パターン + `updated_at` 自動更新 + FTS5 `replace_source_documents()` で原子的再インデックス
+  - `search(query, source_type?, tags?)` を実装: FTS5 `search_index()` + Python post-filter (source_type, tags)
+  - `rebuild_index()` を実装: 全ソース + 全ナレッジを収集して `build_index()` に渡す
+  - Purpose: カタログの更新・検索・インデックス再構築を提供する
+  - _Leverage: src/insight_blueprint/core/designs.py (model_copy pattern), src/insight_blueprint/storage/sqlite_store.py_
+  - _Requirements: FR-5 (update), FR-9 (search/rebuild)_
+  - **完了基準**:
+    1. `tests/test_catalog.py` の update/search/rebuild テスト（12件追加、合計26件）すべてが pass する
+    2. `update_source` が `updated_at` を自動更新し、変更されたフィールドのみ書き換える
+    3. `search` が FTS5 結果を返し、`source_type` と `tags` フィルタが正しく動作する
+    4. `add_source` 直後に `search` で即座に検索可能（`rebuild_index` 不要）
+    5. `rebuild_index` 後にすべてのソース + ナレッジが検索可能
+    6. FTS5 DB 未存在時に `search` が空リストを返す（例外なし）
+    7. `poe all` が pass する
+  - **確認手続き**: `poe test -- tests/test_catalog.py -v` で全テスト pass を確認。`poe all` で全体チェック
+  - _Prompt: Implement the task for spec SPEC-2, first run spec-workflow-guide to get the workflow guide then implement the task: Role: Python developer specializing in service layer and search integration | Task: Extend CatalogService with update_source (model_copy + updated_at + FTS5 replace_source_documents), search (FTS5 search_index + Python post-filter by source_type/tags), rebuild_index (collect all sources+knowledge then build_index) per FR-5/FR-9 | Restrictions: update_source follows DesignService.update_design pattern; search post-filter loads source YAML to check type/tags; rebuild_index must handle empty catalog gracefully; FTS5 failure in update must not cause update_source to fail | Success: 12 additional tests pass (update patches, updated_at refresh, untouched fields intact, missing returns None, persists to YAML, search matches, search filters by type, search filters by tags, search empty when no DB, rebuild creates DB, add then immediate search works); poe all passes | After completing implementation and tests: (1) mark task [-] to [x] in tasks.md (2) log implementation with log-implementation tool_
+
+- [x] 3.1 Implement MCP tools: add_catalog_entry, update_catalog_entry, get_table_schema
+  - File: src/insight_blueprint/server.py (拡張), tests/test_server.py (拡張)
+  - `_catalog_service: CatalogService | None` モジュールレベル変数を追加
+  - `get_catalog_service()` guard 関数を追加（`RuntimeError` on uninitialized）
+  - `add_catalog_entry(source_id, name, type, description, connection, columns, tags?, primary_key?, row_count_estimate?)` を実装: DataSource 構築 → add_source → success dict
+  - `update_catalog_entry(source_id, name?, description?, connection?, columns?, tags?)` を実装: 部分更新 → updated dict
+  - `get_table_schema(source_id)` を実装: source の schema_info から columns/primary_key/row_count_estimate を返す
+  - ValueError（duplicate ID, invalid type）は `{"error": ...}` dict に変換
+  - Purpose: カタログ登録・更新・スキーマ取得を MCP ツールとして公開する
+  - _Leverage: src/insight_blueprint/server.py (既存 design tools の error dict パターン)_
+  - _Requirements: FR-10, FR-11, FR-12_
+  - **完了基準**:
+    1. `tests/test_server.py` の catalog tool テスト（8件追加）すべてが pass する
+    2. `get_catalog_service()` が未初期化時に `RuntimeError` を raise する
+    3. `add_catalog_entry` が success dict を返し、duplicate で error dict を返す
+    4. `update_catalog_entry` が更新後の full dict を返し、missing で error dict を返す
+    5. `get_table_schema` が columns list を返し、missing で error dict を返す
+    6. invalid type (`"parquet"`) で error dict を返す
+    7. `poe all` が pass する
+  - **確認手続き**: `poe test -- tests/test_server.py -v` で全テスト pass を確認。`poe all` で全体チェック
+  - _Prompt: Implement the task for spec SPEC-2, first run spec-workflow-guide to get the workflow guide then implement the task: Role: Python developer specializing in FastMCP tool implementation | Task: Add 3 catalog MCP tools to server.py per FR-10/FR-11/FR-12 — add_catalog_entry (construct DataSource from flat params, call add_source), update_catalog_entry (partial update), get_table_schema (return columns+primary_key+row_count_estimate); add _catalog_service module-level var and get_catalog_service() guard | Restrictions: Follow existing design tool patterns exactly; all tools async def; return dicts not Pydantic models; catch ValueError for duplicate ID and invalid SourceType; add_catalog_entry accepts flat columns as list[dict] and builds schema_info internally | Success: 8 tests pass covering get_catalog_service guard, add success, add duplicate error, add invalid type error, update success, update missing error, get_table_schema success, get_table_schema missing error; poe all passes | After completing implementation and tests: (1) mark task [-] to [x] in tasks.md (2) log implementation with log-implementation tool_
+
+- [x] 3.2 Implement MCP tools: search_catalog, get_domain_knowledge
+  - File: src/insight_blueprint/server.py (拡張), tests/test_server.py (拡張)
+  - `search_catalog(query, source_type?, tags?)` を実装: tags はカンマ区切り文字列 → list 変換 → CatalogService.search() → `{results, count}`
+  - `get_domain_knowledge(source_id, category?)` を実装: category の KnowledgeCategory バリデーション → CatalogService.get_knowledge() → `{source_id, entries, count}`
+  - invalid category は `{"error": ...}` dict に変換
+  - Purpose: カタログ検索とドメインナレッジ参照を MCP ツールとして公開する
+  - _Leverage: src/insight_blueprint/server.py (既存 error dict パターン)_
+  - _Requirements: FR-13, FR-14_
+  - **完了基準**:
+    1. `tests/test_server.py` の search/knowledge ツールテスト（7件追加）すべてが pass する
+    2. `search_catalog` が `{results: [...], count: N}` を返す
+    3. `search_catalog` に `source_type` フィルタが正しく動作する
+    4. `get_domain_knowledge` が `{source_id, entries, count}` を返す
+    5. invalid category で error dict を返す
+    6. missing source で error dict を返す
+    7. `poe all` が pass する
+  - **確認手続き**: `poe test -- tests/test_server.py -v` で全テスト pass を確認。`poe all` で全体チェック
+  - _Prompt: Implement the task for spec SPEC-2, first run spec-workflow-guide to get the workflow guide then implement the task: Role: Python developer specializing in FastMCP tool implementation | Task: Add 2 catalog MCP tools to server.py per FR-13/FR-14 — search_catalog (parse comma-separated tags string, call CatalogService.search, return {results, count}), get_domain_knowledge (validate category via KnowledgeCategory enum, call get_knowledge, return {source_id, entries, count}) | Restrictions: Follow existing tool patterns; tags param is comma-separated string split to list; invalid KnowledgeCategory returns error dict not exception; missing source returns error dict; all tools async def | Success: 7 tests pass covering search results dict, search empty returns zero count, search with source_type filter, get_domain_knowledge returns entries, get_domain_knowledge missing returns error, get_domain_knowledge with category filter, get_domain_knowledge invalid category returns error; poe all passes | After completing implementation and tests: (1) mark task [-] to [x] in tasks.md (2) log implementation with log-implementation tool_
+
+- [x] 4.1 CLI wiring, project init updates, and integration test
+  - File: src/insight_blueprint/cli.py, src/insight_blueprint/storage/project.py, tests/test_integration.py (拡張), tests/test_storage.py (拡張)
+  - `cli.py` を修正: `CatalogService(project_path)` をインスタンス化し `server._catalog_service` に wire。`rebuild_index()` を `mcp.run()` の前に呼び出す
+  - `storage/project.py` を修正: `_copy_skills_template()` を拡張して `catalog-register` skill もコピー
+  - `tests/test_integration.py` にカタログラウンドトリップテストを追加: init → add_source → get_source → get_schema → search (即座に検索可能) → search with type filter (0 results) → get_knowledge
+  - `tests/test_storage.py` に新テストを追加: `.sqlite/` dir 作成、catalog-register skill コピー
+  - Purpose: CLI 起動時のカタログ初期化と、全レイヤー貫通の統合テストを完成させる
+  - _Leverage: src/insight_blueprint/cli.py (既存の DesignService wiring pattern), src/insight_blueprint/storage/project.py (既存の _copy_skills_template pattern)_
+  - _Requirements: FR-15, FR-16, AC 全般_
+  - **完了基準**:
+    1. `tests/test_integration.py` のカタログラウンドトリップテストが pass する
+    2. `tests/test_storage.py` の新テスト（3件）すべてが pass する
+    3. 既存の SPEC-1/1a テスト（43件）すべてが pass する（回帰なし）
+    4. `poe all` が pass する（ruff + ty + pytest）
+    5. `core/catalog.py` と `storage/sqlite_store.py` のカバレッジが 80% 以上
+  - **確認手続き**:
+    - `poe all` で全チェック pass を確認
+    - `uv run pytest --cov=src/insight_blueprint --cov-report=term-missing` でカバレッジ確認（core/catalog.py, storage/sqlite_store.py が 80%+）
+    - `uv run pytest -v` で全テスト数を確認（既存43件 + SPEC-2 新規テストすべて pass）
+  - **手動確認手続き（ユーザー実施）**:
+    - 以下のコマンドを実行して MCP サーバーの起動と `.insight/` 構造を確認してください:
+      ```
+      cd /tmp && mkdir -p spec2-test && uvx insight-blueprint --project /tmp/spec2-test
+      ```
+    - **期待値**: MCP サーバーが stdio モードで起動する（Ctrl+C で終了）
+    - 起動後、別ターミナルで以下を確認:
+      ```
+      ls /tmp/spec2-test/.insight/catalog/sources/    # ディレクトリが存在する
+      ls /tmp/spec2-test/.insight/.sqlite/             # ディレクトリが存在する
+      ls /tmp/spec2-test/.claude/skills/catalog-register/  # SKILL.md が存在する
+      ```
+    - **期待値**: 3 つのパスすべてが存在する
+  - _Prompt: Implement the task for spec SPEC-2, first run spec-workflow-guide to get the workflow guide then implement the task: Role: Python developer specializing in CLI integration and end-to-end testing | Task: Wire CatalogService in cli.py (instantiate, set server._catalog_service, call rebuild_index before mcp.run); extend _copy_skills_template in project.py for catalog-register skill; add catalog round-trip integration test and storage tests per FR-15/FR-16 | Restrictions: CatalogService wiring must happen BEFORE mcp.run(); rebuild_index must not crash on empty catalog; catalog-register skill copy follows same pattern as analysis-design; do NOT modify existing SPEC-1 tests; integration test must verify immediate searchability after add (no rebuild needed) | Success: Integration test passes full round-trip (add → get → schema → search → type filter → knowledge); test_storage.py new tests pass (.sqlite dir, catalog-register skill copy); all 43 existing tests pass (no regression); poe all passes; coverage >= 80% for core/catalog.py and storage/sqlite_store.py | After completing implementation and tests: (1) mark task [-] to [x] in tasks.md (2) log implementation with log-implementation tool_
+
+- [x] 4.2 Create /catalog-register bundled skill
+  - File: src/insight_blueprint/_skills/catalog-register/SKILL.md
+  - YAML frontmatter を含む SKILL.md を作成: `name: catalog-register`, `description` にトリガーフレーズ含む, `disable-model-invocation: true`
+  - CSV ソース登録ワークフロー: ファイルヘッダー読込 → ColumnSchema 構築 → add_catalog_entry 呼び出し
+  - API ソース登録ワークフロー: エンドポイント確認 → レスポンス構造分析 → ColumnSchema 構築 → add_catalog_entry 呼び出し
+  - SQL ソース登録ワークフロー: INFORMATION_SCHEMA クエリ → カラムメタデータ取得 → add_catalog_entry 呼び出し
+  - 各ソースタイプの `connection` dict フォーマットをガイドに含める
+  - Purpose: データソースの自動探索と登録を Claude Code スキルとして提供する
+  - _Leverage: src/insight_blueprint/_skills/analysis-design/SKILL.md (既存スキルフォーマット), .claude/rules/skill-format.md_
+  - _Requirements: FR-17_
+  - **完了基準**:
+    1. SKILL.md が `.claude/rules/skill-format.md` の規則に準拠する
+    2. YAML frontmatter に `name`, `description`, `disable-model-invocation: true` が含まれる
+    3. CSV/API/SQL の 3 ソースタイプすべてのワークフローが記載されている
+    4. 各ワークフローが `add_catalog_entry` MCP ツールの呼び出しで完了する
+    5. `poe lint` が pass する（SKILL.md は lint 対象外だが、他ファイルに変更がないことを確認）
+  - **手動確認手続き（ユーザー実施）**:
+    1. **SKILL.md フォーマット確認**:
+       - `src/insight_blueprint/_skills/catalog-register/SKILL.md` を開く
+       - **期待値**: ファイル先頭に `---` で囲まれた YAML frontmatter があり、以下のキーが存在する:
+         - `name: catalog-register`
+         - `description:` （複数行、「データカタログ」「register」などのトリガーフレーズを含む）
+         - `disable-model-invocation: true`
+    2. **ワークフロー内容確認**:
+       - SKILL.md 本文に CSV / API / SQL の 3 セクションがあることを確認
+       - **期待値**: 各セクションに (a) データ構造探索手順, (b) ColumnSchema 構築方法, (c) `add_catalog_entry` 呼び出し例が含まれる
+    3. **実際の動作確認（任意）**:
+       - Claude Code で `/catalog-register` と入力し、スキルが読み込まれることを確認
+       - **期待値**: Claude Code がソースタイプの選択を尋ね、選択したタイプに応じた探索ワークフローを開始する
+  - _Prompt: Implement the task for spec SPEC-2, first run spec-workflow-guide to get the workflow guide then implement the task: Role: Claude Code skill designer specializing in data exploration workflows | Task: Create SKILL.md for /catalog-register per FR-17 with YAML frontmatter (name, description with trigger phrases, disable-model-invocation: true); include 3 source type workflows — CSV (read headers, infer types), API (e-Stat pattern: getMetaInfo endpoint), SQL (BigQuery INFORMATION_SCHEMA queries); each workflow ends with add_catalog_entry MCP tool call; include connection dict format examples for each type | Restrictions: Follow .claude/rules/skill-format.md format rules; SKILL.md under 300 lines; description must include Japanese trigger phrases (「データカタログ登録」「ソース登録」); do NOT include implementation code — only Claude Code instructions; language of SKILL.md body is English (per skill-format.md) | Success: SKILL.md has valid frontmatter with name/description/disable-model-invocation; 3 source type workflows documented; each workflow references add_catalog_entry tool; file is under 300 lines | After completing implementation: (1) mark task [-] to [x] in tasks.md (2) log implementation with log-implementation tool_

--- a/.spec-workflow/specs/SPEC-3/design.md
+++ b/.spec-workflow/specs/SPEC-3/design.md
@@ -1,0 +1,537 @@
+# SPEC-3: review-workflow — Design
+
+> **Spec ID**: SPEC-3
+> **Status**: draft
+> **Created**: 2026-02-26
+> **Depends On**: SPEC-1 (core-foundation), SPEC-2 (data-catalog)
+
+---
+
+## Overview
+
+SPEC-3 adds a review workflow layer to insight-blueprint. Data scientists submit
+analysis designs for review, receive structured feedback as persistent comments, and
+the system automatically extracts reusable domain knowledge from those comments.
+The review workflow follows the same 3-layer architecture as SPEC-1 and SPEC-2:
+MCP tools (server.py) → ReviewService/RulesService (core/) → Storage (yaml_store.py).
+Two new service modules (`core/reviews.py` and `core/rules.py`) are introduced, along
+with a new model module (`models/review.py`) for review-specific data types.
+Knowledge extraction follows an Extract-Preview-Confirm pattern: entries are extracted
+as preview, confirmed by the user (with scope adjustment), then persisted.
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+
+- **Storage**: Review comments persisted as per-design YAML files in
+  `.insight/designs/{design_id}_reviews.yaml`; extracted knowledge in
+  `.insight/rules/extracted_knowledge.yaml` — YAML remains source of truth per tech.md
+- **MCP tools**: 6 new async tools registered with `@mcp.tool()` on the existing
+  `FastMCP("insight-blueprint")` instance
+- **Quality**: TDD (Red-Green-Refactor), ruff + ty + pytest, 80%+ coverage target
+- **No new dependencies**: Uses only existing packages (pydantic, ruamel.yaml, etc.)
+- **Status lifecycle**: `DesignStatus` extended with `pending_review` — single StrEnum definition
+- **Model extension**: `AnalysisDesign` extended with `source_ids: list[str]` for data source scoping
+
+### Project Structure (structure.md)
+
+- **New modules** per Spec-to-Module Mapping: `models/review.py`, `core/rules.py`,
+  `core/reviews.py`
+- **Modified modules**: `server.py` (+6 tools, +1 transition guard), `cli.py` (+service wiring),
+  `storage/project.py` (+extracted_knowledge init), `models/design.py` (+pending_review),
+  `models/__init__.py` (+re-exports)
+- **3-layer separation**: MCP tools → ReviewService/RulesService → yaml_store + DesignService
+- **One-directional dependencies**: server.py → core/{reviews,rules}.py → storage/* + core/designs.py
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+
+- **`now_jst()`** (`models/common.py`): Timestamps for `ReviewComment.created_at`
+- **`read_yaml/write_yaml`** (`storage/yaml_store.py`): All YAML persistence for review comments,
+  extracted knowledge — atomic writes via `tempfile.mkstemp()` + `os.replace()`
+- **`DesignService`** (`core/designs.py`): `ReviewService` delegates to `DesignService.get_design()`
+  and `DesignService.update_design()` for status transitions — no direct YAML access for designs
+- **`CatalogService.get_knowledge()`** (`core/catalog.py`): `RulesService.get_project_context()`
+  aggregates catalog knowledge alongside extracted review knowledge
+- **`DomainKnowledgeEntry`** (`models/catalog.py`): Reused for extracted knowledge entries —
+  same structure, stored in `rules/extracted_knowledge.yaml`
+- **`get_service()` guard pattern** (`server.py`): `get_review_service()` and
+  `get_rules_service()` follow same `RuntimeError` guard for uninitialized service
+- **MCP error dict pattern** (`server.py`): `ValueError` → `{"error": str(e)}` conversion
+
+### Integration Points
+
+- **`server.py`**: New `_review_service` and `_rules_service` module-level references +
+  6 `@mcp.tool()` functions + guard on `update_analysis_design` to reject `pending_review`
+- **`cli.py`**: `ReviewService` and `RulesService` instantiated and wired before `mcp.run()`
+- **`storage/project.py`**: `_create_insight_dirs()` extended to create
+  `rules/extracted_knowledge.yaml` (empty entries)
+- **`models/design.py`**: `DesignStatus` extended with `pending_review` value
+- **`models/__init__.py`**: Re-export `ReviewComment` from `models/review.py`
+
+## Architecture
+
+### Modular Design Principles
+
+- **Single File Responsibility**: `models/review.py` = review data models only,
+  `core/reviews.py` = review workflow operations only, `core/rules.py` = knowledge
+  aggregation only
+- **Component Isolation**: `ReviewService` depends on `DesignService` interface only
+  (get/update) — no direct YAML manipulation of design files. `RulesService` reads
+  catalog knowledge via `CatalogService` — no direct file access to catalog YAML
+- **Service Layer Separation**: MCP tools → ReviewService/RulesService → DesignService/
+  CatalogService/yaml_store. No cross-layer skipping
+- **Utility Modularity**: Status transition validation is a standalone dict/set definition
+  in `core/reviews.py`, importable for testing
+
+### Component Diagram (SPEC-3 additions)
+
+```
+Claude Code (AI Client)
+       |
+  stdio (MCP Protocol)
+       |
+  +-------------------------------------------------------+
+  |  insight-blueprint (Python Process)                   |
+  |                                                       |
+  |  cli.py (entry point)                                 |
+  |    ├── init_project()                                 |
+  |    ├── wire DesignService                             |
+  |    ├── wire CatalogService                            |
+  |    ├── wire ReviewService(design_svc)       ← NEW     |
+  |    ├── wire RulesService(catalog_svc)       ← NEW     |
+  |    ├── rebuild_index()                                |
+  |    └── mcp.run() ← BLOCKS                            |
+  |                                                       |
+  |  server.py (FastMCP)                                  |
+  |    ├── [4 existing design tools]                      |
+  |    │   └── update_analysis_design ← GUARD added       |
+  |    ├── [5 existing catalog tools]                     |
+  |    ├── submit_for_review              ← NEW           |
+  |    ├── save_review_comment            ← NEW           |
+  |    ├── extract_domain_knowledge       ← NEW (preview) |
+  |    ├── save_extracted_knowledge       ← NEW (persist) |
+  |    ├── get_project_context            ← NEW           |
+  |    └── suggest_cautions               ← NEW           |
+  |           ↓                                           |
+  |  core/reviews.py (ReviewService)      ← NEW          |
+  |    ├── submit_for_review()                            |
+  |    ├── save_review_comment()                          |
+  |    ├── list_comments()                                |
+  |    ├── extract_domain_knowledge()                     |
+  |    └── save_extracted_knowledge()                     |
+  |           ↓ delegates to                              |
+  |  core/designs.py (DesignService)      (existing)     |
+  |                                                       |
+  |  core/rules.py (RulesService)         ← NEW          |
+  |    ├── get_project_context()                          |
+  |    └── suggest_cautions()                             |
+  |           ↓ reads from                                |
+  |  core/catalog.py (CatalogService)     (existing)     |
+  |  storage/yaml_store.py                (existing)     |
+  +-------------------------------------------------------+
+           ↓
+  .insight/
+    ├── designs/
+    │   ├── FP-H01_hypothesis.yaml
+    │   └── FP-H01_reviews.yaml       ← NEW (per-design)
+    ├── catalog/knowledge/             (existing)
+    ├── rules/
+    │   ├── review_rules.yaml          (existing)
+    │   ├── analysis_rules.yaml        (existing)
+    │   └── extracted_knowledge.yaml   ← NEW
+    └── .sqlite/
+```
+
+### Design Decision: Status Transition Matrix
+
+Based on Codex risk analysis (Risk #7): The existing `update_analysis_design` MCP tool
+can set `status` directly, potentially bypassing the review workflow. To prevent this:
+
+- A `VALID_TRANSITIONS` dict is defined in `core/reviews.py` as single source of truth
+- `submit_for_review()` validates `active → pending_review` only
+- `save_review_comment()` validates `pending_review → {active, supported, rejected, inconclusive}`
+- `update_analysis_design` in `server.py` is guarded to reject `pending_review` as a target status
+- The `draft → active` transition remains possible via `update_analysis_design` (existing behavior)
+
+```python
+VALID_REVIEW_TRANSITIONS: dict[DesignStatus, set[DesignStatus]] = {
+    DesignStatus.active: {DesignStatus.pending_review},
+    DesignStatus.pending_review: {
+        DesignStatus.active,      # request changes
+        DesignStatus.supported,
+        DesignStatus.rejected,
+        DesignStatus.inconclusive,
+    },
+}
+```
+
+### Design Decision: Separate Review Comment Files
+
+Based on Codex risk analysis (Risk #3): Review comments are stored in a separate
+`{design_id}_reviews.yaml` file rather than inline in the design YAML.
+
+- **Rationale**: Design files stay focused on hypothesis/analysis structure; review
+  history can grow unbounded; separate files are easier to list/search
+- **Trade-off**: Two files per reviewed design (vs. one). Acceptable since the files
+  are in the same directory and linked by naming convention
+- **Concurrency**: For v1 single-user, atomic `os.replace()` is sufficient.
+  The read-modify-write pattern for appending comments is acceptable
+
+### Design Decision: Extract-Preview-Confirm Pattern
+
+Based on Codex risk analysis (Risk #4) + reviewer feedback on scoping accuracy:
+Knowledge extraction follows a two-step Extract-Preview-Confirm pattern to prevent
+false positive cautions from being persisted.
+
+- **Rationale**: Extracted knowledge becomes permanent project context that Claude uses
+  across sessions. Persisting incorrectly scoped knowledge (e.g., a population-specific
+  caution applied to all data sources) causes false positive cautions that mislead
+  analysis. Human confirmation before persistence eliminates this risk.
+- **Implementation**:
+  - `extract_domain_knowledge(design_id)` → returns preview (no persistence)
+  - `save_extracted_knowledge(design_id, entries)` → persists after user confirmation
+  - Keyword-based extraction: regex prefix detection (case-insensitive), NFKC Unicode
+    normalization, process by line (each line can have its own category)
+  - Scope assignment: `table:` / `テーブル:` annotation per entry, falling back to
+    `AnalysisDesign.source_ids` as default scope
+  - User can adjust `affects_columns` on each entry before save
+- **Scope priority**: user confirmation > `table:` annotation > `design.source_ids` > `[]`
+- **Accepted limitation**: Lower recall for implicit knowledge. Future enhancement:
+  optional LLM extraction mode
+
+### Design Decision: Unified affects_columns Matching
+
+Based on Codex risk analysis (Risk #6) + reviewer feedback: `suggest_cautions()` uses a
+single unified matching strategy for both catalog and extracted knowledge.
+
+- **Strategy**: Match `DomainKnowledgeEntry.affects_columns` against provided
+  `table_names` for all knowledge entries (catalog and extracted alike)
+- **Rationale**: The Extract-Preview-Confirm pattern ensures that extracted knowledge
+  entries have properly populated `affects_columns` at save time. This eliminates the
+  need for a separate content-keyword fallback strategy and avoids the vocabulary
+  mismatch between `affects_columns`, `affects_tables`, and content matching.
+- **Trade-off**: Entries with `affects_columns=[]` (unscoped) will not match any
+  specific table query. This is intentional — unscoped entries appear only in
+  `get_project_context()` (overview), not in targeted `suggest_cautions()` queries.
+  This prevents false positive cautions at the cost of potential false negatives for
+  unscoped entries.
+
+## Components and Interfaces
+
+### `models/review.py`
+
+- **Purpose**: Pydantic data models for review comments
+- **Interfaces**:
+  - `ReviewComment(BaseModel)`: id, design_id, comment, reviewer, status_after,
+    created_at, extracted_knowledge
+- **Dependencies**: `pydantic`, `models/common.py:now_jst`, `models/design.py:DesignStatus`
+- **Reuses**: `now_jst()` for timestamp defaults (same as AnalysisDesign and DataSource)
+
+### `core/reviews.py`
+
+- **Purpose**: Review workflow operations — submit, comment, extract knowledge
+- **Interfaces**:
+  - `VALID_REVIEW_TRANSITIONS: dict[DesignStatus, set[DesignStatus]]` — transition matrix
+  - `ReviewService(project_path: Path, design_service: DesignService)` constructor
+  - `submit_for_review(design_id: str) -> AnalysisDesign | None`
+    — validate active status, transition to pending_review
+  - `save_review_comment(design_id: str, comment: str, status: str, reviewer: str = "analyst") -> ReviewComment | None`
+    — validate pending_review status, persist comment, transition design
+  - `list_comments(design_id: str) -> list[ReviewComment]`
+    — read `{design_id}_reviews.yaml`, return all comments
+  - `extract_domain_knowledge(design_id: str) -> list[DomainKnowledgeEntry]`
+    — parse comments, extract knowledge as preview (NOT persisted),
+      populate `affects_columns` from `table:` annotations or `design.source_ids`
+  - `save_extracted_knowledge(design_id: str, entries: list[DomainKnowledgeEntry]) -> list[DomainKnowledgeEntry]`
+    — persist user-confirmed entries to `rules/extracted_knowledge.yaml`,
+      update `ReviewComment.extracted_knowledge` with saved keys
+- **Dependencies**: `models/review.py`, `models/catalog.py:DomainKnowledgeEntry`,
+  `core/designs.py:DesignService`, `storage/yaml_store.py`
+- **Reuses**: `DesignService.get_design()` and `DesignService.update_design()` for
+  status transitions; `read_yaml/write_yaml` for comment and knowledge persistence
+
+### `core/rules.py`
+
+- **Purpose**: Knowledge aggregation and caution suggestion
+- **Interfaces**:
+  - `RulesService(project_path: Path, catalog_service: CatalogService)` constructor
+  - `get_project_context() -> dict`
+    — aggregate all domain knowledge: catalog sources, catalog knowledge, extracted knowledge,
+      rules; return structured summary
+  - `suggest_cautions(table_names: list[str]) -> list[dict]`
+    — search all domain knowledge entries (catalog and extracted) by matching
+      `affects_columns` against provided table/source names — unified strategy
+- **Dependencies**: `core/catalog.py:CatalogService`, `models/catalog.py`,
+  `storage/yaml_store.py`
+- **Reuses**: `CatalogService.list_sources()`, `CatalogService.get_knowledge()` for
+  catalog data; `read_yaml` for extracted knowledge
+
+### `server.py` (additions)
+
+- **Purpose**: 6 new MCP tools for review workflow + 1 transition guard on existing tool
+- **Interfaces**:
+  - `_review_service: ReviewService | None` — module-level reference
+  - `_rules_service: RulesService | None` — module-level reference
+  - `get_review_service() -> ReviewService` — RuntimeError guard
+  - `get_rules_service() -> RulesService` — RuntimeError guard
+  - `submit_for_review(design_id) -> dict`
+  - `save_review_comment(design_id, comment, status, reviewer?) -> dict`
+  - `extract_domain_knowledge(design_id) -> dict` — preview, not persisted
+  - `save_extracted_knowledge(design_id, entries) -> dict` — persist confirmed entries
+  - `get_project_context() -> dict`
+  - `suggest_cautions(table_names) -> dict`
+  - **MODIFIED**: `update_analysis_design()` — reject `status="pending_review"`
+    with error dict
+- **Dependencies**: `core/reviews.py:ReviewService`, `core/rules.py:RulesService`
+- **Reuses**: Same error dict pattern as existing design and catalog tools
+
+### `models/design.py` (modification)
+
+- **Purpose**: Extend `DesignStatus` with `pending_review` and add `source_ids` to `AnalysisDesign`
+- **Changes**:
+  - Add `pending_review = "pending_review"` to `DesignStatus(StrEnum)`
+  - Add `source_ids: list[str] = Field(default_factory=list)` to `AnalysisDesign`
+- **Impact**: All existing status values and fields preserved; changes are additive
+  and backward-compatible (existing designs default to `source_ids=[]`)
+
+### `storage/project.py` (modifications)
+
+- **Purpose**: Extended `init_project()` for review workflow infrastructure
+- **Changes**: Create `.insight/rules/extracted_knowledge.yaml` with
+  `{source_id: "review", entries: []}` if absent
+- **Reuses**: Existing `write_yaml` for YAML creation, existing directory creation pattern
+
+### `cli.py` (modifications)
+
+- **Purpose**: Wire `ReviewService` and `RulesService` at startup
+- **Changes**:
+  - Import and instantiate `ReviewService(project_path, design_service)`
+  - Import and instantiate `RulesService(project_path, catalog_service)`
+  - Wire `server._review_service` and `server._rules_service`
+  - Both services wired after DesignService and CatalogService, before `mcp.run()`
+
+## Data Models
+
+### ReviewComment YAML (`designs/{design_id}_reviews.yaml`)
+
+```yaml
+comments:
+  - id: "RC-a1b2c3d4"
+    design_id: "FP-H01"
+    comment: |
+      table: population_stats
+      caution: 2015年以降の人口統計は調査方法が変更されているため、
+      直接比較する場合は補正が必要。
+      methodology: 人口動態比較には年齢調整標準化を用いること。
+      definition: MAU = 月間アクティブユーザー数
+      背景: この分析はQ3の事業計画策定を目的としている。
+    reviewer: "analyst"
+    status_after: "supported"
+    created_at: "2026-02-26T10:00:00+09:00"
+    extracted_knowledge:
+      - "FP-H01-0"
+      - "FP-H01-1"
+      - "FP-H01-2"
+      - "FP-H01-3"
+```
+
+### Extracted Knowledge YAML (`rules/extracted_knowledge.yaml`)
+
+```yaml
+source_id: "review"
+entries:
+  - key: "FP-H01-0"
+    title: "2015年以降の人口統計は調査方法が変更されている"
+    content: "2015年以降の人口統計は調査方法が変更されているため、直接比較する場合は補正が必要。"
+    category: "caution"
+    importance: "medium"
+    created_at: "2026-02-26T10:30:00+09:00"
+    source: "Review comment on FP-H01"
+    affects_columns: ["population_stats"]
+  - key: "FP-H01-1"
+    title: "人口動態比較には年齢調整標準化を用いること"
+    content: "人口動態比較には年齢調整標準化を用いること。"
+    category: "methodology"
+    importance: "medium"
+    created_at: "2026-02-26T10:30:00+09:00"
+    source: "Review comment on FP-H01"
+    affects_columns: ["population_stats"]
+  - key: "FP-H01-2"
+    title: "MAU = 月間アクティブユーザー数"
+    content: "MAU = 月間アクティブユーザー数"
+    category: "definition"
+    importance: "medium"
+    created_at: "2026-02-26T10:30:00+09:00"
+    source: "Review comment on FP-H01"
+    affects_columns: []
+  - key: "FP-H01-3"
+    title: "この分析はQ3の事業計画策定を目的としている"
+    content: "この分析はQ3の事業計画策定を目的としている。"
+    category: "context"
+    importance: "medium"
+    created_at: "2026-02-26T10:30:00+09:00"
+    source: "Review comment on FP-H01"
+    affects_columns: []
+```
+
+Note: All four entries were initially proposed with `affects_columns: ["population_stats"]`
+from the sticky `table: population_stats` annotation. During the confirm step, the user
+kept the scope for FP-H01-0 (caution) and FP-H01-1 (methodology) — both are specific to
+the population_stats data source — but adjusted FP-H01-2 (definition) and FP-H01-3
+(context) to unscoped (`[]`) because "MAU" and project background are not data-source-specific.
+This demonstrates the Extract-Preview-Confirm pattern's value: automatic extraction proposes
+scope from annotations, but the user corrects over-scoped entries before persistence.
+
+### ReviewComment Model (models/review.py)
+
+```python
+class ReviewComment(BaseModel):
+    id: str  # "RC-{8hex}"
+    design_id: str
+    comment: str
+    reviewer: str = "analyst"
+    status_after: DesignStatus
+    created_at: datetime = Field(default_factory=now_jst)
+    extracted_knowledge: list[str] = Field(default_factory=list)
+```
+
+## Error Handling
+
+### Error Scenarios
+
+1. **Invalid status transition (submit)** — `submit_for_review()` called on non-active design
+   - **Handling**: `ReviewService` checks `design.status == DesignStatus.active`.
+     Raises `ValueError("Design must be in 'active' status to submit for review, "
+     "current status: '{status}'")`
+   - **User Impact**: Claude receives error dict and can inform the analyst of the
+     required status
+
+2. **Invalid status transition (review)** — `save_review_comment()` called on non-pending design
+   - **Handling**: `ReviewService` checks `design.status == DesignStatus.pending_review`.
+     Raises `ValueError`. Server converts to error dict
+   - **User Impact**: Claude receives error dict and can explain the design must be
+     submitted for review first
+
+3. **Invalid post-review status** — `save_review_comment()` called with `status="pending_review"`
+   or `status="draft"`
+   - **Handling**: `ReviewService` validates against `VALID_REVIEW_TRANSITIONS[pending_review]`.
+     Raises `ValueError("Invalid post-review status 'pending_review'. "
+     "Valid: active, supported, rejected, inconclusive")`
+   - **User Impact**: Claude receives error dict with valid status list
+
+4. **Design not found** — Any review operation called with nonexistent design_id
+   - **Handling**: `DesignService.get_design()` returns `None`.
+     ReviewService propagates `None`. Server converts to `{"error": "Design 'xyz' not found"}`
+   - **User Impact**: Claude receives error dict and can suggest correct design ID
+
+5. **Bypass attempt via update_analysis_design** — `update_analysis_design(status="pending_review")`
+   - **Handling**: `update_analysis_design` in `server.py` checks if target status is
+     `pending_review` and returns `{"error": "Cannot set status to 'pending_review' directly. "
+     "Use submit_for_review() instead."}`
+   - **User Impact**: Claude is redirected to the correct workflow tool
+
+6. **No comments for extraction** — `extract_domain_knowledge()` called on design with no comments
+   - **Handling**: `list_comments()` returns empty list. `extract_domain_knowledge` returns empty list
+   - **User Impact**: Tool returns `{entries: [], count: 0}` — no error
+
+7. **Save without preview** — `save_extracted_knowledge()` called with entries that
+   have no `key` or invalid structure
+   - **Handling**: `save_extracted_knowledge` validates each entry has required fields
+     (`key`, `content`, `category`). Raises `ValueError` for invalid entries
+   - **User Impact**: Claude receives error dict and can re-run extraction preview
+
+8. **ReviewService/RulesService not initialized** — MCP tool called before CLI wiring
+   - **Handling**: `get_review_service()`/`get_rules_service()` raises `RuntimeError`
+     (same pattern as `get_service()`)
+   - **User Impact**: MCP protocol returns error. Only occurs in test/dev scenarios
+
+## Testing Strategy
+
+### Unit Testing
+
+| File | Coverage Target |
+|------|----------------|
+| `tests/test_review_models.py` | `models/review.py` + `models/design.py` extension — 7 tests |
+| `tests/test_reviews.py` | `core/reviews.py` — 22 tests |
+| `tests/test_rules.py` | `core/rules.py` — 10 tests |
+| `tests/test_server.py` (extended) | server.py review tools — 14 tests |
+| `tests/test_storage.py` (extended) | project.py changes — 2 tests |
+
+**test_review_models.py** (model validation):
+- ReviewComment creation with now_jst default
+- ReviewComment creation with empty extracted_knowledge default
+- ReviewComment JSON round-trip (serialize + deserialize equivalence)
+- AnalysisDesign.source_ids default to empty list
+- AnalysisDesign.source_ids with explicit values preserved
+- DesignStatus.pending_review value
+- ReviewComment with DesignStatus.supported as status_after
+
+**test_reviews.py** (ReviewService operations):
+- `submit_for_review`: active design → pending_review, non-active raises ValueError, missing returns None
+- `save_review_comment`: pending → supported/rejected/inconclusive/active, non-pending raises ValueError, invalid status raises ValueError, missing returns None
+- `list_comments`: returns comments in order, empty for no file, empty for nonexistent
+- `extract_domain_knowledge` (preview): caution/definition/methodology/context extraction, no-prefix defaults to context, empty comments returns empty, table: annotation scoping, design.source_ids default scoping, entries returned as preview (not persisted)
+- `save_extracted_knowledge` (persist): entries persisted to YAML, duplicate keys skipped, ReviewComment.extracted_knowledge updated
+
+**test_rules.py** (RulesService operations):
+- `get_project_context`: aggregates catalog sources + catalog knowledge + extracted knowledge, handles empty gracefully
+- `suggest_cautions`: matches all knowledge entries via affects_columns (unified strategy), returns empty for no matches, handles mixed sources
+
+### Integration Testing
+
+- Full round-trip test in `tests/test_integration.py`:
+  `create_design()` → `update_design(status="active")` → `submit_for_review()` →
+  `save_review_comment(comment, "supported")` → `extract_domain_knowledge()` →
+  `save_extracted_knowledge(entries)` → `get_project_context()` (includes extracted knowledge) →
+  `suggest_cautions()` — all with real YAML files
+- Existing SPEC-1/SPEC-2 tests continue to pass (regression check)
+- `update_analysis_design(status="pending_review")` returns error dict (guard test)
+
+### End-to-End Testing
+
+Full MCP protocol E2E testing remains out of scope (same as SPEC-1/SPEC-2).
+Integration tests cover the full business logic stack.
+
+### Acceptance Criteria × Test Case Mapping
+
+| AC | Content (Summary) | Test Cases | File |
+|----|-------------------|------------|------|
+| R1-AC1 | pending_review enum value | `test_design_status_pending_review_value` | `test_review_models.py` |
+| R1-AC2 | ReviewComment now_jst default | `test_review_comment_timestamps_default_to_jst` | `test_review_models.py` |
+| R1-AC3 | ReviewComment JSON round-trip | `test_review_comment_json_round_trip` | `test_review_models.py` |
+| R1-AC4 | AnalysisDesign.source_ids default | `test_analysis_design_source_ids_default_empty` | `test_review_models.py` |
+| R1-AC5 | ReviewComment extracted_knowledge default | `test_review_comment_extracted_knowledge_default_empty` | `test_review_models.py` |
+| R2-AC1 | submit active → pending_review | `test_submit_for_review_active_design` | `test_reviews.py` |
+| R2-AC2 | submit draft raises ValueError | `test_submit_for_review_draft_raises_value_error` | `test_reviews.py` |
+| R2-AC3 | submit missing returns None | `test_submit_for_review_missing_returns_none` | `test_reviews.py` |
+| R2-AC4 | save comment + status supported | `test_save_review_comment_sets_status_supported` | `test_reviews.py` |
+| R2-AC5 | save comment + status active (changes) | `test_save_review_comment_sets_status_active` | `test_reviews.py` |
+| R2-AC6 | save on draft raises ValueError | `test_save_review_comment_on_draft_raises_value_error` | `test_reviews.py` |
+| R2-AC7 | save with pending_review raises | `test_save_review_comment_pending_review_invalid` | `test_reviews.py` |
+| R2-AC8 | two comments listed in order | `test_list_comments_returns_both_in_order` | `test_reviews.py` |
+| R2-AC9 | list_comments nonexistent empty | `test_list_comments_nonexistent_returns_empty` | `test_reviews.py` |
+| R3-AC1 | extract caution category | `test_extract_caution_from_comment` | `test_reviews.py` |
+| R3-AC2 | extract definition category | `test_extract_definition_from_comment` | `test_reviews.py` |
+| R3-AC3 | extract returns preview (not persisted) | `test_extract_returns_preview_not_persisted` | `test_reviews.py` |
+| R3-AC4 | save persists to YAML | `test_save_extracted_persists_to_yaml` | `test_reviews.py` |
+| R3-AC5 | save duplicate keys skipped | `test_save_extracted_duplicate_keys_skipped` | `test_reviews.py` |
+| R3-AC6 | no comments returns empty | `test_extract_no_comments_returns_empty` | `test_reviews.py` |
+| R3-AC7 | no prefix defaults to context | `test_extract_no_prefix_defaults_to_context` | `test_reviews.py` |
+| R3-AC8 | table: annotation sets affects_columns | `test_extract_table_annotation_sets_scope` | `test_reviews.py` |
+| R3-AC9 | design.source_ids used as default scope | `test_extract_design_source_ids_default_scope` | `test_reviews.py` |
+| R3-AC10 | no annotation + no source_ids = unscoped | `test_extract_no_scope_defaults_to_empty` | `test_reviews.py` |
+| R4-AC1 | submit_for_review tool success | `test_submit_for_review_tool_success` | `test_server.py` |
+| R4-AC2 | submit_for_review tool error | `test_submit_for_review_tool_non_active_error` | `test_server.py` |
+| R4-AC3 | save_review_comment tool success | `test_save_review_comment_tool_success` | `test_server.py` |
+| R4-AC4 | save_review_comment tool invalid status | `test_save_review_comment_tool_invalid_status` | `test_server.py` |
+| R4-AC5 | extract_domain_knowledge tool (preview) | `test_extract_domain_knowledge_tool_preview` | `test_server.py` |
+| R4-AC6 | save_extracted_knowledge tool (persist) | `test_save_extracted_knowledge_tool` | `test_server.py` |
+| R4-AC7 | get_project_context tool | `test_get_project_context_tool` | `test_server.py` |
+| R4-AC8 | suggest_cautions tool with matches | `test_suggest_cautions_tool_with_matches` | `test_server.py` |
+| R4-AC9 | suggest_cautions tool no matches | `test_suggest_cautions_tool_no_matches` | `test_server.py` |
+| R5-AC1 | CLI wires services (6 tools) | `test_review_full_round_trip` | `test_integration.py` |
+| R5-AC2 | init creates extracted_knowledge | `test_init_project_creates_extracted_knowledge_yaml` | `test_storage.py` |
+| R5-AC3 | full flow with preview-confirm | `test_review_full_round_trip` | `test_integration.py` |
+| — | update_analysis_design guard | `test_update_design_rejects_pending_review` | `test_server.py` |

--- a/.spec-workflow/specs/SPEC-3/requirements.md
+++ b/.spec-workflow/specs/SPEC-3/requirements.md
@@ -1,0 +1,330 @@
+# SPEC-3: review-workflow — Requirements
+
+> **Spec ID**: SPEC-3
+> **Feature Name**: review-workflow
+> **Status**: draft
+> **Created**: 2026-02-25
+> **Depends On**: SPEC-1 (core-foundation), SPEC-2 (data-catalog)
+
+---
+
+## Introduction
+
+SPEC-3 adds a review workflow to insight-blueprint so that data scientists can submit
+analysis designs for structured review, capture reviewer feedback as persistent comments,
+and automatically extract reusable domain knowledge from those comments. Extracted
+knowledge is persisted to YAML and made available through MCP tools that provide
+project-wide analytical context and data-specific cautions. This creates a continuously
+growing knowledge base that Claude Code leverages across EDA sessions.
+
+## Alignment with Product Vision
+
+This spec directly enables three core product goals defined in `product.md`:
+
+- **Accumulating domain knowledge from analyst review comments for continuous reuse**:
+  The review workflow captures reviewer insights (methodology notes, data cautions,
+  definition clarifications) as structured `ReviewComment` records. `extract_domain_knowledge()`
+  parses these into `DomainKnowledgeEntry` items persisted to YAML — building a growing
+  knowledge base session over session.
+- **Communicating data access rules and domain knowledge to AI**:
+  `get_project_context()` and `suggest_cautions(table_names)` give Claude Code structured
+  access to all accumulated domain knowledge (from both SPEC-2 catalog sources and SPEC-3
+  review comments), enabling it to proactively warn analysts about data pitfalls and provide
+  relevant analytical context.
+- **Spec Roadmap progression**: SPEC-3 is the third spec in the dependency chain. It
+  extends SPEC-1's `AnalysisDesign` with a review status lifecycle and SPEC-2's
+  `DomainKnowledge` with review-sourced entries. SPEC-4 (webui-dashboard) will surface
+  the review workflow in the Rules and History tabs.
+
+## Requirements
+
+### Requirement 1: Review Workflow Models
+
+**User Story:** As a data scientist, I want analysis designs to have a review status
+lifecycle with structured review comments, so that feedback is captured formally and
+the design's review state is always clear.
+
+**FR-1: DesignStatus Extension**
+- Extend `DesignStatus(StrEnum)` in `models/design.py` with a new value: `pending_review`
+- Valid status transitions for review workflow:
+  - `active` → `pending_review` (analyst submits for review)
+  - `pending_review` → `active` (reviewer requests changes)
+  - `pending_review` → `supported` (reviewer concludes: hypothesis supported)
+  - `pending_review` → `rejected` (reviewer concludes: hypothesis rejected)
+  - `pending_review` → `inconclusive` (reviewer concludes: inconclusive)
+- Only `submit_for_review()` may transition to `pending_review`; only `save_review_comment()`
+  may transition away from `pending_review`
+
+**FR-2: ReviewComment Model**
+- New `ReviewComment(BaseModel)` in `models/review.py` with fields:
+  - `id: str` — auto-generated short ID (format: `RC-{8-char-hex}`)
+  - `design_id: str` — references `AnalysisDesign.id`
+  - `comment: str` — free-text review feedback
+  - `reviewer: str` (default `"analyst"`)
+  - `status_after: DesignStatus` — design status after this review action
+  - `created_at: datetime` (default `now_jst()`)
+  - `extracted_knowledge: list[str]` — keys of extracted `DomainKnowledgeEntry` items
+    (default empty list)
+
+**FR-3: AnalysisDesign Extension — source_ids**
+- Extend `AnalysisDesign` in `models/design.py` with a new optional field:
+  - `source_ids: list[str]` — IDs of data sources this design analyzes (default empty list)
+- Backward-compatible: existing designs without `source_ids` default to `[]`
+- Used as default scope when extracting domain knowledge from review comments
+
+#### Acceptance Criteria
+
+1. WHEN `DesignStatus("pending_review")` is created THEN the value `"pending_review"` is stored correctly
+2. WHEN a `ReviewComment` is created without `created_at` THEN `now_jst()` is used as default
+3. WHEN a `ReviewComment` is serialized via `model_dump(mode="json")` and deserialized back THEN the round-trip produces an equivalent model
+4. WHEN an `AnalysisDesign` is created without `source_ids` THEN it defaults to an empty list
+5. WHEN a `ReviewComment` is created without `extracted_knowledge` THEN it defaults to an empty list
+
+### Requirement 2: Review Operations
+
+**User Story:** As a data scientist using Claude Code, I want to submit my analysis
+design for review and receive structured feedback, so that the review process is tracked
+and all comments are preserved.
+
+**FR-4: Submit for Review**
+- `ReviewService.submit_for_review(design_id)` transitions design status from `active` to
+  `pending_review` via `DesignService.update_design()`
+- If design is not found, returns `None`
+- If design status is not `active`, raises `ValueError` with message indicating valid
+  source status (e.g., "Design must be in 'active' status to submit for review")
+- Returns the updated `AnalysisDesign`
+
+**FR-5: Save Review Comment**
+- `ReviewService.save_review_comment(design_id, comment, status, reviewer?)` performs:
+  1. Validates that `status` is a valid post-review `DesignStatus`
+     (one of: `active`, `supported`, `rejected`, `inconclusive`)
+  2. Validates that the design is in `pending_review` status
+  3. Creates a `ReviewComment` with auto-generated ID
+  4. Appends the comment to `.insight/designs/{design_id}_reviews.yaml`
+  5. Updates the design status to the provided `status` via `DesignService.update_design()`
+  6. Returns the created `ReviewComment`
+- If design is not found, returns `None`
+- If design is not in `pending_review` status, raises `ValueError`
+- If `status` is `pending_review` or `draft`, raises `ValueError` (invalid post-review status)
+- Multiple comments can be saved for the same design (review → request changes → re-review)
+
+**FR-6: List Review Comments**
+- `ReviewService.list_comments(design_id)` reads
+  `.insight/designs/{design_id}_reviews.yaml` and returns all `ReviewComment` items
+- Returns empty list if no comments file exists
+
+#### Acceptance Criteria
+
+1. WHEN `submit_for_review(design_id)` is called on an `active` design THEN status changes to `pending_review` and `updated_at` is refreshed
+2. WHEN `submit_for_review(design_id)` is called on a `draft` design THEN `ValueError` is raised
+3. WHEN `submit_for_review("nonexistent")` is called THEN `None` is returned
+4. WHEN `save_review_comment(design_id, "Good analysis", "supported")` is called on a `pending_review` design THEN comment is persisted AND design status changes to `supported`
+5. WHEN `save_review_comment(design_id, "Needs more data", "active")` is called THEN design status changes to `active` (request changes flow)
+6. WHEN `save_review_comment` is called on a `draft` design THEN `ValueError` is raised
+7. WHEN `save_review_comment` is called with `status="pending_review"` THEN `ValueError` is raised (invalid post-review status)
+8. WHEN two comments are saved for the same design (after re-submitting) THEN `list_comments` returns both comments in chronological order
+9. WHEN `list_comments("nonexistent")` is called THEN empty list is returned
+
+### Requirement 3: Domain Knowledge Extraction
+
+**User Story:** As a data scientist, I want domain knowledge to be automatically
+extracted from review comments and saved to the knowledge base, so that insights
+captured during reviews are reusable in future analysis sessions.
+
+**FR-7a: Extract Domain Knowledge (Preview)**
+- `ReviewService.extract_domain_knowledge(design_id)` performs:
+  1. Reads all review comments for the design via `list_comments()`
+  2. Reads `AnalysisDesign.source_ids` as default scope
+  3. For each comment, extracts structured knowledge entries using keyword-based heuristics:
+     - Lines containing `"caution:"` or `"注意:"` → `KnowledgeCategory.caution`
+     - Lines containing `"definition:"` or `"定義:"` → `KnowledgeCategory.definition`
+     - Lines containing `"methodology:"` or `"手法:"` → `KnowledgeCategory.methodology`
+     - Lines containing `"context:"` or `"背景:"` → `KnowledgeCategory.context`
+     - Lines containing `"table:"` or `"テーブル:"` → sets entry-level scope
+       (overrides design default for subsequent entries until next `table:` line)
+     - Remaining non-empty lines without category prefix → `KnowledgeCategory.context` (default)
+  4. Creates `DomainKnowledgeEntry` for each extracted item with:
+     - `key`: `"{design_id}-{index}"` (e.g., `"FP-H01-0"`)
+     - `title`: first 80 characters of extracted text
+     - `content`: full extracted text
+     - `category`: detected category
+     - `source`: `"Review comment on {design_id}"`
+     - `importance`: `medium` (default)
+     - `affects_columns`: entry-level scope if `table:` annotation present,
+       otherwise `design.source_ids` (default scope)
+  5. Returns list of extracted entries as preview (does NOT persist to YAML)
+- If design has no comments, returns empty list
+- Scope priority: `table:` annotation (entry-level) > `design.source_ids` (default) > `[]` (unscoped)
+
+**FR-7b: Save Extracted Knowledge (Persist)**
+- `ReviewService.save_extracted_knowledge(design_id, entries)` performs:
+  1. Accepts a list of user-confirmed `DomainKnowledgeEntry` items
+     (with `affects_columns` adjusted by user if needed)
+  2. Persists entries to `.insight/rules/extracted_knowledge.yaml`
+  3. Updates the `ReviewComment.extracted_knowledge` list with the saved keys
+  4. Returns list of saved `DomainKnowledgeEntry` items
+- Duplicate keys (from re-extraction) are skipped — no overwriting
+- Entries should be reviewed and confirmed by user before calling this method
+
+**FR-8: Knowledge Persistence Format**
+- Extracted knowledge is stored in `.insight/rules/extracted_knowledge.yaml`
+- Format: `DomainKnowledge` wrapper with `source_id: "review"` and
+  `entries: list[DomainKnowledgeEntry-dicts]` — same container structure as
+  SPEC-2 catalog knowledge files
+- Each `DomainKnowledgeEntry` includes `affects_columns` populated during extraction
+  (from `table:` annotation or `AnalysisDesign.source_ids`)
+- New entries are appended to existing entries (accumulative, not overwritten)
+
+#### Acceptance Criteria
+
+1. WHEN `extract_domain_knowledge(design_id)` is called and comments contain "caution: watch for nulls in column X" THEN a `DomainKnowledgeEntry` with `category=caution` is returned in preview
+2. WHEN comments contain "definition: MAU = Monthly Active Users" THEN a `DomainKnowledgeEntry` with `category=definition` is returned in preview
+3. WHEN `extract_domain_knowledge(design_id)` is called THEN entries are returned as preview (NOT persisted to YAML)
+4. WHEN `save_extracted_knowledge(design_id, entries)` is called THEN entries are persisted to `.insight/rules/extracted_knowledge.yaml`
+5. WHEN `save_extracted_knowledge` is called twice with same keys THEN duplicate keys are skipped (no duplicates in YAML)
+6. WHEN `extract_domain_knowledge` is called for a design with no comments THEN empty list is returned
+7. WHEN a comment line has no recognized category prefix THEN the extracted entry defaults to `category=context`
+8. WHEN a comment contains "table: population_stats" followed by "caution: ..." THEN the extracted entry has `affects_columns=["population_stats"]`
+9. WHEN a comment has no "table:" annotation and design has `source_ids=["X", "Y"]` THEN extracted entries have `affects_columns=["X", "Y"]`
+10. WHEN a comment has no "table:" annotation and design has `source_ids=[]` THEN extracted entries have `affects_columns=[]`
+
+### Requirement 4: MCP Tools
+
+**User Story:** As a data scientist using Claude Code, I want Claude to manage the
+review workflow, extract knowledge, and provide project context through MCP tools,
+so that the full review lifecycle is accessible during analysis sessions.
+
+**FR-9: submit_for_review Tool**
+- Accepts: `design_id: str`
+- Returns: `{design_id, status, message}` on success, `{error}` on failure
+- Maps to `ReviewService.submit_for_review()`
+
+**FR-10: save_review_comment Tool**
+- Accepts: `design_id: str`, `comment: str`, `status: str`, `reviewer: str` (default `"analyst"`)
+- Returns: `{comment_id, design_id, status_after, message}` on success, `{error}` on failure
+- Maps to `ReviewService.save_review_comment()`
+
+**FR-11a: extract_domain_knowledge Tool (Preview)**
+- Accepts: `design_id: str`
+- Returns: `{design_id, entries: [{key, content, category, suggested_scope}, ...], count, message}`
+  on success, `{error}` on failure
+- Entries are returned as preview — not persisted until `save_extracted_knowledge` is called
+- Maps to `ReviewService.extract_domain_knowledge()`
+
+**FR-11b: save_extracted_knowledge Tool (Persist)**
+- Accepts: `design_id: str`, `entries: list[{key, content, category, scope}]`
+- Returns: `{design_id, saved_entries: [...], count, message}` on success, `{error}` on failure
+- Should be called after user has reviewed and optionally adjusted scopes from preview
+- Maps to `ReviewService.save_extracted_knowledge()`
+
+**FR-12: get_project_context Tool**
+- Accepts: no required parameters
+- Returns: `{sources: [...], knowledge_entries: [...], rules: [...], total_sources, total_knowledge, total_rules}`
+- Aggregates domain knowledge from:
+  - `catalog/knowledge/*.yaml` (per-source knowledge from SPEC-2)
+  - `.insight/rules/extracted_knowledge.yaml` (review-extracted knowledge)
+- Maps to `RulesService.get_project_context()`
+
+**FR-13: suggest_cautions Tool**
+- Accepts: `table_names: str` (comma-separated string of source/table names)
+- Returns: `{table_names: [...], cautions: [...], count}`
+- Searches all domain knowledge entries (catalog and extracted) by matching
+  `affects_columns` against provided `table_names` — single unified matching strategy
+- Maps to `RulesService.suggest_cautions()`
+
+#### Acceptance Criteria
+
+1. WHEN `submit_for_review(design_id)` is called with a valid active design THEN `{design_id, status: "pending_review", message}` is returned
+2. WHEN `submit_for_review(design_id)` is called with a non-active design THEN `{error}` dict is returned
+3. WHEN `save_review_comment(design_id, "Good", "supported")` is called THEN `{comment_id, design_id, status_after: "supported", message}` is returned
+4. WHEN `save_review_comment` is called with invalid status THEN `{error}` dict is returned
+5. WHEN `extract_domain_knowledge(design_id)` is called THEN `{design_id, entries: [{key, content, category, suggested_scope}, ...], count, message}` is returned (preview, not persisted)
+6. WHEN `save_extracted_knowledge(design_id, entries)` is called with confirmed entries THEN `{design_id, saved_entries, count, message}` is returned and entries are persisted
+7. WHEN `get_project_context()` is called THEN aggregated knowledge from all sources is returned
+8. WHEN `suggest_cautions(table_names="population,sales")` is called THEN relevant cautions matching those tables via `affects_columns` are returned
+9. WHEN `suggest_cautions` is called with tables that have no cautions THEN `{table_names, cautions: [], count: 0}` is returned
+
+### Requirement 5: CLI Wiring and Integration
+
+**User Story:** As a data scientist, I want the review workflow to be ready immediately
+when I start insight-blueprint, so that I can submit designs for review and access
+project context right away.
+
+**FR-14: CLI Startup Integration**
+- `cli.py` instantiates `ReviewService(project_path, design_service)` and wires it to
+  `server._review_service`
+- `cli.py` instantiates `RulesService(project_path, catalog_service)` and wires it to
+  `server._rules_service`
+- Both services are wired before `mcp.run()`
+
+**FR-15: Project Initialization Updates**
+- `init_project()` creates `.insight/rules/extracted_knowledge.yaml` with
+  `{source_id: "review", entries: []}` if not present
+- Existing `.insight/designs/` and `.insight/rules/` directories already created by SPEC-1
+
+#### Acceptance Criteria
+
+1. WHEN `uvx insight-blueprint --project /path` is run THEN `ReviewService` and `RulesService` are initialized and all 6 review MCP tools are available
+2. WHEN `init_project()` is called THEN `.insight/rules/extracted_knowledge.yaml` is created (if absent) with `{source_id: "review", entries: []}`
+3. WHEN the full flow `submit_for_review()` → `save_review_comment()` → `extract_domain_knowledge()` → user confirms → `save_extracted_knowledge()` is executed THEN knowledge is persisted to YAML and `get_project_context()` returns it
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+
+- **Single Responsibility Principle**: `models/review.py` = data models only,
+  `core/reviews.py` = review operations only, `core/rules.py` = knowledge aggregation only
+- **Three-Layer Separation**: MCP tools (server.py) delegate to `ReviewService` and
+  `RulesService` (core/), which delegate to `yaml_store.py` and `DesignService`;
+  no cross-layer skipping
+- **Pattern Reuse**: `ReviewService` and `RulesService` follow the same structure as
+  `DesignService` and `CatalogService` (constructor with `project_path`, YAML persistence)
+- **Type Annotations Required**: All functions have complete type annotations; `ty check` passes
+- **Code Quality**: `ruff check` passes; `pytest` coverage for `core/reviews.py` and
+  `core/rules.py` is 80% or higher
+
+### Performance
+
+- `submit_for_review()` completes within 100ms (one YAML read + one YAML write)
+- `save_review_comment()` completes within 200ms (two YAML reads + two YAML writes)
+- `extract_domain_knowledge()` completes within 500ms for up to 50 review comments
+- `get_project_context()` completes within 500ms for up to 100 sources and 500 knowledge entries
+- `suggest_cautions()` completes within 200ms for up to 500 knowledge entries
+
+### Security
+
+- No hardcoded secrets, API keys, or credentials in source code
+- Error messages do not expose internal file paths or stack traces to MCP clients
+- User-provided review comment content is stored as-is (no code execution on comments)
+- Knowledge extraction uses simple string matching — no eval/exec on user content
+
+### Reliability
+
+- All YAML writes remain atomic (`tempfile.mkstemp()` + `os.replace()`)
+- Missing design: `submit_for_review()` and `save_review_comment()` return `None` (no crash)
+- Missing reviews file: `list_comments()` returns empty list
+- Missing `extracted_knowledge.yaml`: `get_project_context()` treats it as empty
+- Existing SPEC-1/SPEC-2 tests continue to pass (no regressions)
+- `extract_domain_knowledge()` with no comments returns empty list (no crash)
+- Status transition validation prevents invalid state changes
+
+### Usability
+
+- MCP tool docstrings clearly describe parameters, valid status values, and return formats
+- `submit_for_review` error messages indicate the current status and valid source status
+- `save_review_comment` error messages include list of valid post-review statuses
+- `get_project_context` returns a well-structured summary for Claude Code to present
+- `suggest_cautions` returns human-readable caution entries for easy display
+
+## Out of Scope
+
+- Real-time collaborative review (only single-reviewer workflow in v1)
+- AI-powered knowledge extraction using LLM (keyword-based heuristics only in v1)
+- Review notification system (no email/webhook notifications)
+- Review assignment workflow (reviewer is implicitly the analyst or a designated reviewer)
+- WebUI review interface (SPEC-4 will add this)
+- Version history for extracted knowledge (no rollback capability)
+- Custom knowledge category definitions (uses SPEC-2's fixed `KnowledgeCategory` enum)
+- Automatic FTS5 indexing of extracted knowledge (future enhancement)
+- `Rule` model and rule-based knowledge management (replaced by unified
+  `DomainKnowledgeEntry` with `affects_columns` scoping via Extract-Preview-Confirm workflow)

--- a/.spec-workflow/specs/SPEC-3/tasks.md
+++ b/.spec-workflow/specs/SPEC-3/tasks.md
@@ -1,0 +1,175 @@
+# SPEC-3: review-workflow — Tasks
+
+> **Spec ID**: SPEC-3
+> **Status**: draft
+> **Created**: 2026-02-26
+> **Depends On**: SPEC-1 (core-foundation), SPEC-2 (data-catalog)
+
+---
+
+## Dependency Graph
+
+```
+1.1 ──→ 1.2 ──→ 2.1 ──→ 2.2 ──→ 4.1 ──→ 4.2 ──→ 5.1
+                                   ↑
+                  3.1 ─────────────┘
+```
+
+---
+
+## Completion Criteria
+
+| # | Criterion | Metric |
+|---|-----------|--------|
+| C1 | All tasks completed | 8/8 tasks marked `[x]` |
+| C2 | New unit tests pass | 56 tests green (3 + 4 + 13 + 9 + 10 + 14 + 2 + 1) |
+| C3 | No regressions | All existing SPEC-1/SPEC-2 tests still pass |
+| C4 | Quality gate passes | `poe all` (ruff + ty + pytest) exits 0 |
+| C5 | MCP tools registered | 6 new tools callable via FastMCP instance |
+| C6 | Integration round-trip | `test_review_full_round_trip` covers submit → comment → extract → save → context → cautions |
+
+## Verification Procedures
+
+1. **Run full quality gate**
+   ```bash
+   poe all
+   ```
+   - Confirm: exit code 0, zero ruff violations, zero ty errors, all pytest tests pass
+
+2. **Verify test counts**
+   ```bash
+   pytest --co -q | tail -1
+   ```
+   - Confirm: total test count = previous count + 56 new tests
+
+3. **Verify MCP tool registration**
+   ```bash
+   pytest tests/test_server.py -v -k "review or rules or knowledge or caution or context"
+   ```
+   - Confirm: 14 server tests pass, covering all 6 new tools + pending_review guard
+
+4. **Verify integration round-trip**
+   ```bash
+   pytest tests/test_integration.py::test_review_full_round_trip -v
+   ```
+   - Confirm: full Extract-Preview-Confirm flow passes with real YAML files
+
+5. **Verify no regressions**
+   ```bash
+   pytest tests/test_integration.py -v
+   ```
+   - Confirm: `test_full_round_trip`, `test_catalog_full_round_trip`, and `test_review_full_round_trip` all pass
+
+---
+
+- [x] 1.1 Extend DesignStatus and add source_ids to AnalysisDesign
+  - File: `src/insight_blueprint/models/design.py`, `tests/test_review_models.py`
+  - Add `pending_review = "pending_review"` to `DesignStatus(StrEnum)`
+  - Add `source_ids: list[str] = Field(default_factory=list)` to `AnalysisDesign`
+  - TDD: Write 3 tests first (Red), then implement (Green)
+    - `test_design_status_pending_review_value` — AC1
+    - `test_analysis_design_source_ids_default_empty` — AC4
+    - `test_analysis_design_source_ids_with_values` — extra
+  - Purpose: Foundation for review status lifecycle and knowledge scoping
+  - _Leverage: existing `DesignStatus(StrEnum)` definition, existing `AnalysisDesign` model_
+  - _Requirements: FR-1, FR-3_
+  - _Prompt: Role: Python Developer with Pydantic expertise | Task: Extend DesignStatus enum with pending_review and add source_ids field to AnalysisDesign, writing tests first per TDD | Restrictions: Additive changes only — do not modify existing enum values or fields. Backward-compatible (existing YAML without source_ids must load) | Success: 3 tests pass, existing SPEC-1 design tests still pass, ty check passes_
+
+- [x] 1.2 Create ReviewComment model and update re-exports
+  - File: `src/insight_blueprint/models/review.py` (NEW), `src/insight_blueprint/models/__init__.py`, `tests/test_review_models.py`
+  - Create `ReviewComment(BaseModel)` with fields: id, design_id, comment, reviewer, status_after, created_at, extracted_knowledge
+  - Update `models/__init__.py` to re-export `ReviewComment`
+  - TDD: Write 4 tests first (Red), then implement (Green)
+    - `test_review_comment_timestamps_default_to_jst` — AC2
+    - `test_review_comment_extracted_knowledge_default_empty` — AC5
+    - `test_review_comment_json_round_trip` — AC3
+    - `test_review_comment_status_after_supported` — extra
+  - Purpose: Data model for structured review feedback
+  - _Leverage: `now_jst()` from `models/common.py`, `DesignStatus` from `models/design.py`_
+  - _Requirements: FR-2_
+  - _Prompt: Role: Python Developer with Pydantic expertise | Task: Create ReviewComment model in new models/review.py file with all specified fields and defaults, update __init__.py re-exports, writing tests first per TDD | Restrictions: Only ReviewComment in this file (no Rule model). Follow existing model patterns (now_jst default, Field defaults) | Success: 4 tests pass, total 7 model tests pass, ruff + ty pass_
+
+- [x] 2.1 Implement ReviewService core operations (submit, comment, list)
+  - File: `src/insight_blueprint/core/reviews.py` (NEW), `tests/test_reviews.py` (NEW), `tests/conftest.py`
+  - Create `ReviewService(project_path, design_service)` with:
+    - `VALID_REVIEW_TRANSITIONS` dict as single source of truth
+    - `submit_for_review(design_id)` — validate active, transition to pending_review
+    - `save_review_comment(design_id, comment, status, reviewer)` — validate pending_review, persist comment YAML, transition design
+    - `list_comments(design_id)` — read reviews YAML, return all
+  - Add shared fixtures to `conftest.py`: `design_service`, `review_service`, `active_design`, `pending_design`
+  - TDD: Write 13 tests first (Red), then implement (Green)
+    - TestSubmitForReview: 3 tests (AC1-AC3 of R2)
+    - TestSaveReviewComment: 7 tests (AC4-AC7 of R2 + status variations)
+    - TestListComments: 3 tests (AC8-AC9 of R2 + empty)
+  - Purpose: Core review workflow — submit designs for review and capture structured feedback
+  - _Leverage: `DesignService.get_design()` / `update_design()`, `read_yaml` / `write_yaml` from `yaml_store.py`_
+  - _Requirements: FR-4, FR-5, FR-6_
+  - _Prompt: Role: Python Developer with DDD and TDD expertise | Task: Implement ReviewService with submit_for_review, save_review_comment, list_comments. Define VALID_REVIEW_TRANSITIONS as source of truth. Write 13 tests first per TDD | Restrictions: Delegate to DesignService for design operations — no direct YAML manipulation of design files. Atomic writes via write_yaml. Do not implement extract/save knowledge in this task | Success: 13 tests pass, status transitions enforced, comments persisted to {design_id}_reviews.yaml_
+
+- [x] 2.2 Implement extract_domain_knowledge and save_extracted_knowledge
+  - File: `src/insight_blueprint/core/reviews.py`, `tests/test_reviews.py`
+  - Add to `ReviewService`:
+    - `extract_domain_knowledge(design_id)` — keyword-based extraction with regex prefix detection, NFKC normalization, `table:` annotation scoping, `design.source_ids` default scope. Returns preview (NOT persisted)
+    - `save_extracted_knowledge(design_id, entries)` — persist confirmed entries to `rules/extracted_knowledge.yaml`, update ReviewComment.extracted_knowledge
+  - TDD: Write 9 tests first (Red), then implement (Green)
+    - TestExtractDomainKnowledge: 6 tests (AC1-AC3, AC6-AC10 of R3)
+    - TestSaveExtractedKnowledge: 3 tests (AC4-AC5 of R3 + comment update)
+  - Purpose: Extract-Preview-Confirm pattern — extract reusable domain knowledge from review comments with user-confirmable scoping
+  - _Leverage: `list_comments()` from task 2.1, `DesignService.get_design()` for source_ids, `read_yaml` / `write_yaml`, `DomainKnowledgeEntry` from `models/catalog.py`_
+  - _Requirements: FR-7a, FR-7b, FR-8_
+  - _Prompt: Role: Python Developer with regex and text processing expertise | Task: Implement extract_domain_knowledge (preview) and save_extracted_knowledge (persist) in ReviewService. Use regex prefix detection (case-insensitive), NFKC normalization, table: annotation scoping with design.source_ids fallback. Write 9 tests first per TDD | Restrictions: extract returns preview only — no persistence. save persists to rules/extracted_knowledge.yaml using DomainKnowledge wrapper (source_id: "review"). Duplicate keys skipped. Scope priority: table: annotation > design.source_ids > [] | Success: 9 tests pass, total 22 ReviewService tests pass, all 4 categories extracted, scoping works correctly_
+
+- [x] 3.1 Implement RulesService (get_project_context, suggest_cautions)
+  - File: `src/insight_blueprint/core/rules.py` (NEW), `tests/test_rules.py` (NEW)
+  - Create `RulesService(project_path, catalog_service)` with:
+    - `get_project_context()` — aggregate catalog sources + catalog knowledge + extracted knowledge + rules YAML content
+    - `suggest_cautions(table_names)` — unified `affects_columns` matching against all knowledge entries
+  - TDD: Write 10 tests first (Red), then implement (Green)
+    - TestGetProjectContext: 5 tests (catalog sources, catalog knowledge, extracted knowledge, empty, rule files)
+    - TestSuggestCautions: 5 tests (catalog match, extracted match, mixed, no match, unscoped not returned)
+  - Purpose: Knowledge aggregation and targeted caution suggestion for Claude Code
+  - _Leverage: `CatalogService.list_sources()` / `get_knowledge()`, `read_yaml` for extracted knowledge and rule files_
+  - _Requirements: FR-12, FR-13_
+  - _Prompt: Role: Python Developer with data aggregation expertise | Task: Implement RulesService with get_project_context and suggest_cautions. get_project_context aggregates all knowledge sources. suggest_cautions uses unified affects_columns matching. Write 10 tests first per TDD | Restrictions: Read-only access to catalog via CatalogService interface. Unified matching strategy — no content keyword fallback. Unscoped entries (affects_columns=[]) excluded from suggest_cautions | Success: 10 tests pass, project context aggregates all sources correctly, caution matching is accurate with no false positives_
+
+- [x] 4.1 Add 6 MCP tools to server.py and pending_review guard
+  - File: `src/insight_blueprint/server.py`, `tests/test_server.py`
+  - Add module-level references: `_review_service`, `_rules_service`
+  - Add guard functions: `get_review_service()`, `get_rules_service()`
+  - Add 6 `@mcp.tool()` functions: `submit_for_review`, `save_review_comment`, `extract_domain_knowledge`, `save_extracted_knowledge`, `get_project_context`, `suggest_cautions`
+  - Add guard on existing `update_analysis_design` to reject `status="pending_review"`
+  - TDD: Write 14 tests first (Red) with mocked services, then implement (Green)
+    - submit_for_review: 3 tests (success, error, not found)
+    - save_review_comment: 3 tests (success, invalid status, not found)
+    - extract_domain_knowledge: 1 test (preview)
+    - save_extracted_knowledge: 2 tests (success, invalid)
+    - get_project_context: 1 test
+    - suggest_cautions: 2 tests (matches, no matches)
+    - pending_review guard: 1 test
+    - service not initialized: 1 test
+  - Purpose: Expose review workflow to Claude Code via MCP protocol
+  - _Leverage: existing `get_service()` guard pattern, existing error dict pattern (`ValueError → {error: str(e)}`)_
+  - _Requirements: FR-9, FR-10, FR-11a, FR-11b, FR-12, FR-13_
+  - _Prompt: Role: Python Developer with MCP/FastMCP expertise | Task: Add 6 MCP tools and pending_review guard to server.py. Follow existing tool patterns (error dict, guard functions). Write 14 tests with mocked services first per TDD | Restrictions: Tools must delegate to ReviewService/RulesService — no business logic in server.py. Follow existing error dict pattern. Mock services in tests (not YAML) | Success: 14 tests pass, 6 tools registered on FastMCP instance, pending_review guard blocks direct status set, existing server tests still pass_
+
+- [x] 4.2 Wire services in cli.py and update init_project
+  - File: `src/insight_blueprint/cli.py`, `src/insight_blueprint/storage/project.py`, `tests/test_storage.py`
+  - In `cli.py`: import and instantiate `ReviewService(project_path, design_service)` and `RulesService(project_path, catalog_service)`, wire to `server._review_service` and `server._rules_service` before `mcp.run()`
+  - In `storage/project.py`: extend `init_project()` / `_create_insight_dirs()` to create `.insight/rules/extracted_knowledge.yaml` with `{source_id: "review", entries: []}` if absent
+  - TDD: Write 2 tests first (Red), then implement (Green)
+    - `test_init_project_creates_extracted_knowledge_yaml` — AC2 of R5
+    - `test_init_project_does_not_overwrite_existing_extracted_knowledge` — extra
+  - Purpose: Ensure review workflow is ready at startup and storage is initialized
+  - _Leverage: existing service wiring pattern in `cli.py`, existing `_create_insight_dirs()` pattern, `write_yaml`_
+  - _Requirements: FR-14, FR-15_
+  - _Prompt: Role: Python Developer with CLI integration expertise | Task: Wire ReviewService and RulesService in cli.py (after DesignService/CatalogService, before mcp.run). Update init_project to create extracted_knowledge.yaml. Write 2 tests first per TDD | Restrictions: Follow existing wiring order. Idempotent init — do not overwrite existing extracted_knowledge.yaml. Services wired after their dependencies | Success: 2 tests pass, existing init tests still pass, services available at startup_
+
+- [x] 5.1 Full round-trip integration test and regression verification
+  - File: `tests/test_integration.py`
+  - Add `test_review_full_round_trip`: create_design → update(active) → submit_for_review → save_review_comment → extract_domain_knowledge → save_extracted_knowledge → get_project_context → suggest_cautions
+  - Verify existing `test_full_round_trip` and `test_catalog_full_round_trip` still pass
+  - Run `poe all` (ruff + ty + pytest) for final quality gate
+  - Purpose: End-to-end validation of the complete Extract-Preview-Confirm flow with real YAML files
+  - _Leverage: existing integration test patterns, `tmp_project` fixture, all new services_
+  - _Requirements: FR-14 (R5-AC1), R5-AC3_
+  - _Prompt: Role: QA Engineer with integration testing expertise | Task: Write full round-trip integration test covering the complete review workflow including Extract-Preview-Confirm. Verify all existing tests still pass (no regressions). Run full quality gate | Restrictions: Use real YAML files (no mocks). Test must cover submit → comment → extract (preview) → save (persist) → context → cautions. Do not modify existing test functions | Success: Integration test passes, all existing SPEC-1/SPEC-2 tests pass, poe all succeeds (ruff + ty + pytest)_

--- a/.spec-workflow/specs/SPEC-3/test-design.md
+++ b/.spec-workflow/specs/SPEC-3/test-design.md
@@ -1,0 +1,499 @@
+# SPEC-3: review-workflow — Test Design
+
+> **Spec ID**: SPEC-3
+> **Status**: draft
+> **Created**: 2026-02-26
+> **Depends On**: SPEC-1 (core-foundation), SPEC-2 (data-catalog)
+
+---
+
+## Test Architecture
+
+### Test Pyramid
+
+```
+          ┌──────────┐
+          │ E2E (MCP) │  ← Out of scope (same as SPEC-1/2)
+          ├──────────┤
+        ┌─┤Integration├─┐  ← test_integration.py (round-trip)
+        │ ├──────────┤ │
+  ┌─────┴─┴──────────┴─┴─────┐
+  │     Unit Tests (55 tests)  │  ← 5 test files
+  └───────────────────────────┘
+```
+
+### Test File Layout
+
+| File | Target Module | Test Count | Pattern |
+|------|--------------|-----------|---------|
+| `tests/test_review_models.py` | `models/review.py` + `models/design.py` extension | 7 | Function-based |
+| `tests/test_reviews.py` | `core/reviews.py` | 22 | Class-based (per method) |
+| `tests/test_rules.py` | `core/rules.py` | 10 | Class-based (per method) |
+| `tests/test_server.py` (extended) | `server.py` review tools | 14 | Function-based (existing pattern) |
+| `tests/test_storage.py` (extended) | `storage/project.py` init extension | 2 | Function-based (existing pattern) |
+| `tests/test_integration.py` (extended) | Full round-trip | 1 | Function-based (existing pattern) |
+
+**Total**: 56 new test cases
+
+## Shared Fixtures
+
+### Existing (`conftest.py`)
+
+```python
+@pytest.fixture
+def tmp_project(tmp_path: Path) -> Path:
+    """Return a temporary project directory with .insight/ initialized."""
+    from insight_blueprint.storage.project import init_project
+    init_project(tmp_path)
+    return tmp_path
+```
+
+### New Fixtures to Add (`conftest.py`)
+
+```python
+@pytest.fixture
+def design_service(tmp_project: Path) -> DesignService:
+    """DesignService wired to tmp_project."""
+    return DesignService(tmp_project)
+
+@pytest.fixture
+def catalog_service(tmp_project: Path) -> CatalogService:
+    """CatalogService wired to tmp_project."""
+    return CatalogService(tmp_project)
+
+@pytest.fixture
+def review_service(tmp_project: Path, design_service: DesignService) -> ReviewService:
+    """ReviewService wired to DesignService."""
+    return ReviewService(tmp_project, design_service)
+
+@pytest.fixture
+def rules_service(tmp_project: Path, catalog_service: CatalogService) -> RulesService:
+    """RulesService wired to CatalogService."""
+    return RulesService(tmp_project, catalog_service)
+
+@pytest.fixture
+def active_design(design_service: DesignService) -> AnalysisDesign:
+    """Create a design in active status (ready for submit_for_review)."""
+    design = design_service.create_design(
+        title="Test Hypothesis",
+        hypothesis_statement="Statement",
+        hypothesis_background="Background",
+        theme_id="FP",
+    )
+    return design_service.update_design(design.id, status="active")
+
+@pytest.fixture
+def active_design_with_sources(design_service: DesignService) -> AnalysisDesign:
+    """Create an active design with source_ids for scoping tests."""
+    design = design_service.create_design(
+        title="Population Analysis",
+        hypothesis_statement="Population correlates with GDP",
+        hypothesis_background="Background",
+        theme_id="POP",
+    )
+    updated = design_service.update_design(
+        design.id, status="active", source_ids=["population_stats", "gdp_data"]
+    )
+    return updated
+
+@pytest.fixture
+def pending_design(
+    review_service: ReviewService, active_design: AnalysisDesign
+) -> AnalysisDesign:
+    """Create a design in pending_review status (ready for save_review_comment)."""
+    return review_service.submit_for_review(active_design.id)
+```
+
+### Design Note: Fixture Scope
+
+All fixtures use default `function` scope — each test gets a fresh `tmp_path`, fresh services,
+and clean YAML files. No shared state between tests. This matches SPEC-1/SPEC-2 patterns
+(`test_designs.py`, `test_catalog.py`).
+
+## Test Data
+
+### Sample Review Comments
+
+```python
+# Comment with all 4 knowledge categories + table annotation
+MULTI_CATEGORY_COMMENT = """\
+table: population_stats
+caution: 2015年以降の人口統計は調査方法が変更されているため、直接比較する場合は補正が必要。
+methodology: 人口動態比較には年齢調整標準化を用いること。
+definition: MAU = 月間アクティブユーザー数
+背景: この分析はQ3の事業計画策定を目的としている。
+"""
+
+# Comment with only caution (single category)
+SINGLE_CAUTION_COMMENT = "caution: watch for nulls in column X"
+
+# Comment with definition (English)
+DEFINITION_COMMENT = "definition: MAU = Monthly Active Users"
+
+# Comment with Japanese keywords
+JAPANESE_KEYWORD_COMMENT = """\
+注意: このデータは2020年以降のみ有効。
+定義: DAU = 日次アクティブユーザー数
+手法: 移動平均を用いてトレンド分析を行う。
+テーブル: user_activity
+"""
+
+# Comment with no recognized prefix (defaults to context)
+NO_PREFIX_COMMENT = "This dataset was collected during COVID-19 period, which may affect trends."
+
+# Comment with table annotation mid-comment (scope changes)
+MID_TABLE_COMMENT = """\
+caution: Global caution applying to default scope.
+table: specific_table
+caution: This caution applies only to specific_table.
+"""
+
+# Empty comment
+EMPTY_COMMENT = ""
+```
+
+### Sample Extracted Knowledge Entries
+
+```python
+# For save_extracted_knowledge tests — pre-built DomainKnowledgeEntry list
+SAMPLE_ENTRIES = [
+    DomainKnowledgeEntry(
+        key="FP-H01-0",
+        title="2015年以降の人口統計は調査方法が変更されている",
+        content="2015年以降の人口統計は調査方法が変更されているため、直接比較する場合は補正が必要。",
+        category=KnowledgeCategory.caution,
+        source="Review comment on FP-H01",
+        affects_columns=["population_stats"],
+    ),
+    DomainKnowledgeEntry(
+        key="FP-H01-1",
+        title="MAU = 月間アクティブユーザー数",
+        content="MAU = 月間アクティブユーザー数",
+        category=KnowledgeCategory.definition,
+        source="Review comment on FP-H01",
+        affects_columns=[],
+    ),
+]
+
+# Duplicate entry for skip-duplicate test
+DUPLICATE_ENTRY = DomainKnowledgeEntry(
+    key="FP-H01-0",  # Same key as above
+    title="Duplicate",
+    content="Should be skipped",
+    category=KnowledgeCategory.caution,
+    source="Review comment on FP-H01",
+    affects_columns=["population_stats"],
+)
+```
+
+### Sample Catalog Knowledge (for RulesService tests)
+
+```python
+# Pre-populated catalog knowledge for suggest_cautions cross-source tests
+CATALOG_KNOWLEDGE = DomainKnowledge(
+    source_id="estat-pop",
+    entries=[
+        DomainKnowledgeEntry(
+            key="cat-caution-1",
+            title="Population census methodology change",
+            content="Census methodology changed in 2015",
+            category=KnowledgeCategory.caution,
+            affects_columns=["population_stats"],
+        ),
+        DomainKnowledgeEntry(
+            key="cat-method-1",
+            title="Seasonal adjustment method",
+            content="Use X-12-ARIMA for seasonal adjustment",
+            category=KnowledgeCategory.methodology,
+            affects_columns=["sales_data"],
+        ),
+    ],
+)
+```
+
+## Mock Strategy
+
+### What to Mock
+
+| Dependency | Where | Mock Approach |
+|-----------|-------|--------------|
+| Nothing | `test_review_models.py` | Pure model tests — no mocks |
+| Nothing | `test_reviews.py` | Uses real DesignService + real YAML (via `tmp_project`) |
+| Nothing | `test_rules.py` | Uses real CatalogService + real YAML (via `tmp_project`) |
+| `ReviewService` | `test_server.py` | Service-level mock (mock the service, not YAML) |
+| `RulesService` | `test_server.py` | Service-level mock |
+| Nothing | `test_integration.py` | Full real stack (via `tmp_project`) |
+
+### Design Note: No Mocks for Service Tests
+
+Following SPEC-1/SPEC-2 patterns (`test_designs.py`, `test_catalog.py`), service-level
+tests use **real YAML files** in `tmp_path` rather than mocking `read_yaml`/`write_yaml`.
+This provides higher confidence in the YAML persistence layer and matches the
+existing test approach.
+
+Server tests (`test_server.py`) mock at the **service boundary** — i.e., mock
+`ReviewService`/`RulesService` objects rather than their internal dependencies.
+This tests the MCP tool layer (parameter parsing, error dict conversion) without
+depending on YAML persistence.
+
+## Test Specifications by File
+
+### `test_review_models.py` — 7 Tests
+
+Tests pure Pydantic model behavior. No I/O, no services.
+
+| # | Test Name | AC | Input | Expected |
+|---|-----------|-----|-------|----------|
+| 1 | `test_review_comment_timestamps_default_to_jst` | R1-AC2 | `ReviewComment(id="RC-test", design_id="X", comment="c", status_after=DesignStatus.active)` | `created_at` is `now_jst()` timezone (Asia/Tokyo) |
+| 2 | `test_review_comment_extracted_knowledge_default_empty` | R1-AC5 | Same as above, no `extracted_knowledge` arg | `extracted_knowledge == []` |
+| 3 | `test_review_comment_json_round_trip` | R1-AC3 | `comment.model_dump(mode="json")` → `ReviewComment(**dumped)` | Round-trip produces equivalent model |
+| 4 | `test_analysis_design_source_ids_default_empty` | R1-AC4 | `AnalysisDesign(id="X", ...)` without `source_ids` | `source_ids == []` |
+| 5 | `test_analysis_design_source_ids_with_values` | — | `AnalysisDesign(id="X", ..., source_ids=["a", "b"])` | `source_ids == ["a", "b"]` |
+| 6 | `test_design_status_pending_review_value` | R1-AC1 | `DesignStatus("pending_review")` | Value is `"pending_review"` |
+| 7 | `test_review_comment_status_after_supported` | — | `ReviewComment(..., status_after=DesignStatus.supported)` | `status_after == DesignStatus.supported` |
+
+### `test_reviews.py` — 22 Tests
+
+Tests ReviewService with real YAML files via `tmp_project`.
+
+#### Class: `TestSubmitForReview` (3 tests)
+
+| # | Test Name | AC | Setup | Action | Expected |
+|---|-----------|-----|-------|--------|----------|
+| 1 | `test_submit_for_review_active_design` | R2-AC1 | `active_design` fixture | `submit_for_review(design_id)` | Returns `AnalysisDesign` with `status=pending_review` |
+| 2 | `test_submit_for_review_draft_raises_value_error` | R2-AC2 | Create draft design (no status change) | `submit_for_review(design_id)` | `ValueError("must be in 'active' status")` |
+| 3 | `test_submit_for_review_missing_returns_none` | R2-AC3 | No design created | `submit_for_review("nonexistent")` | Returns `None` |
+
+#### Class: `TestSaveReviewComment` (7 tests)
+
+| # | Test Name | AC | Setup | Action | Expected |
+|---|-----------|-----|-------|--------|----------|
+| 4 | `test_save_review_comment_sets_status_supported` | R2-AC4 | `pending_design` fixture | `save_review_comment(id, "Good", "supported")` | Comment persisted, design status = `supported` |
+| 5 | `test_save_review_comment_sets_status_active` | R2-AC5 | `pending_design` fixture | `save_review_comment(id, "Needs work", "active")` | Design status = `active` (request changes) |
+| 6 | `test_save_review_comment_sets_status_rejected` | — | `pending_design` fixture | `save_review_comment(id, "Not valid", "rejected")` | Design status = `rejected` |
+| 7 | `test_save_review_comment_sets_status_inconclusive` | — | `pending_design` fixture | `save_review_comment(id, "Unclear", "inconclusive")` | Design status = `inconclusive` |
+| 8 | `test_save_review_comment_on_draft_raises_value_error` | R2-AC6 | Create draft design | `save_review_comment(...)` | `ValueError` |
+| 9 | `test_save_review_comment_pending_review_invalid` | R2-AC7 | `pending_design` fixture | `save_review_comment(id, "x", "pending_review")` | `ValueError("Invalid post-review status")` |
+| 10 | `test_save_review_comment_missing_returns_none` | — | No design | `save_review_comment("missing", ...)` | Returns `None` |
+
+#### Class: `TestListComments` (3 tests)
+
+| # | Test Name | AC | Setup | Action | Expected |
+|---|-----------|-----|-------|--------|----------|
+| 11 | `test_list_comments_returns_both_in_order` | R2-AC8 | Submit → comment → re-submit → comment | `list_comments(id)` | 2 comments in chronological order |
+| 12 | `test_list_comments_empty_for_no_reviews_file` | — | `active_design` (no reviews file) | `list_comments(id)` | `[]` |
+| 13 | `test_list_comments_nonexistent_returns_empty` | R2-AC9 | No design | `list_comments("nonexistent")` | `[]` |
+
+#### Class: `TestExtractDomainKnowledge` (9 tests)
+
+| # | Test Name | AC | Setup | Action | Expected |
+|---|-----------|-----|-------|--------|----------|
+| 14 | `test_extract_caution_from_comment` | R3-AC1 | Pending → comment with `SINGLE_CAUTION_COMMENT` → supported | `extract_domain_knowledge(id)` | 1 entry, `category=caution` |
+| 15 | `test_extract_definition_from_comment` | R3-AC2 | Pending → comment with `DEFINITION_COMMENT` → supported | `extract_domain_knowledge(id)` | 1 entry, `category=definition` |
+| 16 | `test_extract_methodology_from_comment` | — | Pending → comment with "methodology: Use X method" → supported | `extract_domain_knowledge(id)` | 1 entry, `category=methodology` |
+| 17 | `test_extract_japanese_keywords` | — | Pending → comment with `JAPANESE_KEYWORD_COMMENT` → supported | `extract_domain_knowledge(id)` | 4 entries (注意→caution, 定義→definition, 手法→methodology, テーブル sets scope) |
+| 18 | `test_extract_returns_preview_not_persisted` | R3-AC3 | Same as #14 | After `extract_domain_knowledge(id)` | `extracted_knowledge.yaml` entries unchanged |
+| 19 | `test_extract_no_comments_returns_empty` | R3-AC6 | Active design, no comments | `extract_domain_knowledge(id)` | `[]` |
+| 20 | `test_extract_no_prefix_defaults_to_context` | R3-AC7 | Pending → comment with `NO_PREFIX_COMMENT` → supported | `extract_domain_knowledge(id)` | 1 entry, `category=context` |
+| 21 | `test_extract_table_annotation_sets_scope` | R3-AC8 | Pending → comment with `MID_TABLE_COMMENT`, design has `source_ids=["default_src"]` | `extract_domain_knowledge(id)` | Entry before `table:` has `affects_columns=["default_src"]`, entry after has `["specific_table"]` |
+| 22 | `test_extract_design_source_ids_default_scope` | R3-AC9 | `active_design_with_sources` → pending → comment (no table:) → supported | `extract_domain_knowledge(id)` | Entry has `affects_columns=["population_stats", "gdp_data"]` |
+
+Note: R3-AC10 (`source_ids=[]` → `affects_columns=[]`) is covered by test #14/#15 which
+use the default `active_design` fixture (no source_ids, defaults to `[]`).
+
+#### Class: `TestSaveExtractedKnowledge` (3 tests — new)
+
+Note: These test `save_extracted_knowledge()` which persists entries. Fixture chain:
+active_design → submit → comment → extract (preview) → **save** (persist).
+
+| # | Test Name | AC | Input | Expected |
+|---|-----------|-----|-------|----------|
+| 23 (new numbering from design.md: included in 22 total) | `test_save_extracted_persists_to_yaml` | R3-AC4 | `save_extracted_knowledge(id, SAMPLE_ENTRIES)` | `extracted_knowledge.yaml` contains 2 entries under `source_id: "review"` |
+| 24 | `test_save_extracted_duplicate_keys_skipped` | R3-AC5 | Save `SAMPLE_ENTRIES`, then save `[DUPLICATE_ENTRY]` | Only 2 entries in YAML (duplicate skipped) |
+| 25 | `test_save_extracted_updates_comment_keys` | — | `save_extracted_knowledge(id, SAMPLE_ENTRIES)` | Corresponding `ReviewComment.extracted_knowledge` contains `["FP-H01-0", "FP-H01-1"]` |
+
+**Note on test count**: 3 + 3 + 7 + 9 + 3 = 25 individual test rows, but design.md claims
+22 tests for `test_reviews.py`. The save tests (3 tests) are included in the 22 count —
+the extract class has 6 tests (not 9) when grouping Japanese keyword + scope tests. The
+table above expands them individually for clarity.
+
+### `test_rules.py` — 10 Tests
+
+Tests RulesService with real YAML files. Requires pre-populated catalog and extracted
+knowledge YAML files.
+
+#### Class: `TestGetProjectContext` (5 tests)
+
+| # | Test Name | AC | Setup | Expected |
+|---|-----------|-----|-------|----------|
+| 1 | `test_get_project_context_includes_catalog_sources` | — | Add `estat-pop` source via CatalogService | `sources` list contains `estat-pop` |
+| 2 | `test_get_project_context_includes_catalog_knowledge` | — | Add source + write `CATALOG_KNOWLEDGE` | `knowledge_entries` includes catalog entries |
+| 3 | `test_get_project_context_includes_extracted_knowledge` | — | Write entries to `extracted_knowledge.yaml` | `knowledge_entries` includes extracted entries |
+| 4 | `test_get_project_context_handles_empty_gracefully` | — | Empty project (no sources, no knowledge) | Returns `{sources: [], knowledge_entries: [], rules: [], ...}` |
+| 5 | `test_get_project_context_includes_rule_files` | — | Default init (review_rules.yaml, analysis_rules.yaml exist) | `rules` contains entries from rule files |
+
+#### Class: `TestSuggestCautions` (5 tests)
+
+| # | Test Name | AC | Setup | Expected |
+|---|-----------|-----|-------|----------|
+| 6 | `test_suggest_cautions_matches_catalog_affects_columns` | — | Add source + `CATALOG_KNOWLEDGE` + rebuild | `suggest_cautions(["population_stats"])` returns 1 caution |
+| 7 | `test_suggest_cautions_matches_extracted_affects_columns` | — | Write `SAMPLE_ENTRIES` to extracted_knowledge.yaml | `suggest_cautions(["population_stats"])` returns entry |
+| 8 | `test_suggest_cautions_mixed_sources` | — | Both catalog and extracted knowledge present | `suggest_cautions(["population_stats"])` returns entries from both sources |
+| 9 | `test_suggest_cautions_no_matches_returns_empty` | — | Knowledge exists but for different tables | `suggest_cautions(["unknown_table"])` returns `[]` |
+| 10 | `test_suggest_cautions_unscoped_not_returned` | — | Entry with `affects_columns=[]` | `suggest_cautions(["any_table"])` does NOT return unscoped entry |
+
+### `test_server.py` (extended) — 14 Tests
+
+Tests MCP tool layer with **mocked services**. Follows existing `test_server.py` patterns.
+
+#### Mock Setup
+
+```python
+@pytest.fixture
+def mock_review_service():
+    """Mock ReviewService for server tool tests."""
+    mock = Mock(spec=ReviewService)
+    import insight_blueprint.server as server_module
+    server_module._review_service = mock
+    yield mock
+    server_module._review_service = None
+
+@pytest.fixture
+def mock_rules_service():
+    """Mock RulesService for server tool tests."""
+    mock = Mock(spec=RulesService)
+    import insight_blueprint.server as server_module
+    server_module._rules_service = mock
+    yield mock
+    server_module._rules_service = None
+```
+
+| # | Test Name | AC | Mock Return | Expected |
+|---|-----------|-----|-------------|----------|
+| 1 | `test_submit_for_review_tool_success` | R4-AC1 | `AnalysisDesign(status=pending_review)` | `{design_id, status: "pending_review", message}` |
+| 2 | `test_submit_for_review_tool_non_active_error` | R4-AC2 | Raises `ValueError` | `{error: "..."}` |
+| 3 | `test_submit_for_review_tool_not_found` | — | Returns `None` | `{error: "Design 'X' not found"}` |
+| 4 | `test_save_review_comment_tool_success` | R4-AC3 | `ReviewComment(status_after=supported)` | `{comment_id, design_id, status_after, message}` |
+| 5 | `test_save_review_comment_tool_invalid_status` | R4-AC4 | Raises `ValueError` | `{error: "..."}` |
+| 6 | `test_save_review_comment_tool_not_found` | — | Returns `None` | `{error: "Design 'X' not found"}` |
+| 7 | `test_extract_domain_knowledge_tool_preview` | R4-AC5 | Returns `[DomainKnowledgeEntry(...)]` | `{design_id, entries: [...], count: 1, message}` |
+| 8 | `test_save_extracted_knowledge_tool` | R4-AC6 | Returns `[DomainKnowledgeEntry(...)]` | `{design_id, saved_entries: [...], count, message}` |
+| 9 | `test_save_extracted_knowledge_tool_invalid` | — | Raises `ValueError` | `{error: "..."}` |
+| 10 | `test_get_project_context_tool` | R4-AC7 | Returns `{sources: [...], ...}` | Dict returned as-is |
+| 11 | `test_suggest_cautions_tool_with_matches` | R4-AC8 | Returns `[{title, content, ...}]` | `{table_names, cautions: [...], count: 1}` |
+| 12 | `test_suggest_cautions_tool_no_matches` | R4-AC9 | Returns `[]` | `{table_names, cautions: [], count: 0}` |
+| 13 | `test_update_design_rejects_pending_review` | — | N/A | `{error: "Cannot set status to 'pending_review' directly..."}` |
+| 14 | `test_review_service_not_initialized_raises` | — | `_review_service = None` | `RuntimeError` |
+
+### `test_storage.py` (extended) — 2 Tests
+
+| # | Test Name | AC | Setup | Expected |
+|---|-----------|-----|-------|----------|
+| 1 | `test_init_project_creates_extracted_knowledge_yaml` | R5-AC2 | `init_project(tmp_path)` | File exists at `.insight/rules/extracted_knowledge.yaml` with `{source_id: "review", entries: []}` |
+| 2 | `test_init_project_does_not_overwrite_existing_extracted_knowledge` | — | Write custom entries → `init_project(tmp_path)` | Custom entries preserved |
+
+### `test_integration.py` (extended) — 1 Test
+
+Full round-trip test with real YAML files, covering the entire Extract-Preview-Confirm flow.
+
+```python
+def test_review_full_round_trip(tmp_project: Path) -> None:
+    """Integration: submit → comment → extract → save → context → cautions."""
+    # 1. Wire services
+    design_service = DesignService(tmp_project)
+    catalog_service = CatalogService(tmp_project)
+    review_service = ReviewService(tmp_project, design_service)
+    rules_service = RulesService(tmp_project, catalog_service)
+
+    # 2. Create active design with source_ids
+    design = design_service.create_design(
+        title="Population Analysis",
+        hypothesis_statement="...",
+        hypothesis_background="...",
+        theme_id="FP",
+    )
+    design_service.update_design(design.id, status="active", source_ids=["population_stats"])
+
+    # 3. Submit for review
+    submitted = review_service.submit_for_review(design.id)
+    assert submitted.status == DesignStatus.pending_review
+
+    # 4. Save review comment with caution
+    comment = review_service.save_review_comment(
+        design.id,
+        "caution: 2015年以降の人口統計は調査方法が変更されている。",
+        "supported",
+    )
+    assert comment is not None
+    assert comment.status_after == DesignStatus.supported
+
+    # 5. Extract knowledge (preview — NOT persisted)
+    preview = review_service.extract_domain_knowledge(design.id)
+    assert len(preview) >= 1
+    assert preview[0].category == KnowledgeCategory.caution
+    assert preview[0].affects_columns == ["population_stats"]  # from design.source_ids
+
+    # 6. Save extracted knowledge (persist)
+    saved = review_service.save_extracted_knowledge(design.id, preview)
+    assert len(saved) >= 1
+
+    # 7. Verify knowledge appears in project context
+    context = rules_service.get_project_context()
+    assert context["total_knowledge"] >= 1
+
+    # 8. Verify caution is suggested for matching table
+    cautions = rules_service.suggest_cautions(["population_stats"])
+    assert len(cautions) >= 1
+
+    # 9. Verify no caution for unrelated table
+    unrelated = rules_service.suggest_cautions(["unrelated_table"])
+    assert len(unrelated) == 0
+```
+
+**Covers**: R5-AC1 (services wired), R5-AC3 (full flow with preview-confirm)
+
+## Edge Case Matrix
+
+### Extract Domain Knowledge — Edge Cases
+
+| Case | Input | Expected | Test |
+|------|-------|----------|------|
+| Empty comment text | `""` | No entries extracted | `test_extract_no_comments_returns_empty` |
+| Whitespace-only lines | `"   \n  \n  "` | No entries extracted | Covered by empty filtering |
+| Mixed English/Japanese prefixes | `"caution: ...\n注意: ..."` | 2 separate entries | `test_extract_japanese_keywords` |
+| Unicode NFKC normalization | Full-width `"ｃａｕｔｉｏｎ："` | Normalized to `"caution:"` → matched | Implicit in keyword detection |
+| Case insensitivity | `"CAUTION: ..."` | Matched as caution | Implicit in regex |
+| Multiple `table:` annotations | `"table: A\ncaution: ...\ntable: B\ncaution: ..."` | First caution → A, second → B | `test_extract_table_annotation_sets_scope` |
+| No `table:` + no `source_ids` | Default design, plain comment | `affects_columns=[]` | `test_extract_no_prefix_defaults_to_context` |
+
+### Save Extracted Knowledge — Edge Cases
+
+| Case | Input | Expected | Test |
+|------|-------|----------|------|
+| Duplicate keys | Save same key twice | Second save skipped | `test_save_extracted_duplicate_keys_skipped` |
+| Empty entries list | `save_extracted_knowledge(id, [])` | No-op, returns `[]` | Implicit |
+| Invalid entry (no key) | Entry missing `key` field | `ValueError` | Error scenario 7 |
+
+### Status Transitions — Edge Cases
+
+| Case | Input | Expected | Test |
+|------|-------|----------|------|
+| Submit draft | `submit_for_review` on draft design | `ValueError` | `test_submit_for_review_draft_raises_value_error` |
+| Submit supported | `submit_for_review` on supported design | `ValueError` | Same test pattern |
+| Comment on draft | `save_review_comment` on draft design | `ValueError` | `test_save_review_comment_on_draft_raises_value_error` |
+| Set `pending_review` via generic update | `update_analysis_design(status="pending_review")` | `{error: "..."}` | `test_update_design_rejects_pending_review` |
+| Re-review cycle | Submit → comment (active) → re-submit → comment (supported) | Both comments listed | `test_list_comments_returns_both_in_order` |
+
+## Regression Strategy
+
+SPEC-3 modifies shared modules (`models/design.py`, `server.py`, `storage/project.py`).
+To ensure no regressions:
+
+1. **Existing SPEC-1/SPEC-2 tests run as-is** — `DesignStatus` extension is additive
+   (new enum value, no existing values changed)
+2. **`init_project` is idempotent** — new `extracted_knowledge.yaml` creation uses
+   `if not exists` guard, matching existing pattern
+3. **`update_analysis_design` guard** — only adds a check for `pending_review`, does not
+   change behavior for any existing status values
+4. **`test_integration.py`** — existing `test_full_round_trip` and
+   `test_catalog_full_round_trip` are preserved; new `test_review_full_round_trip` is added

--- a/.spec-workflow/specs/SPEC-4a/design.md
+++ b/.spec-workflow/specs/SPEC-4a/design.md
@@ -1,0 +1,431 @@
+# SPEC-4a: webui-backend — Design
+
+> **Spec ID**: SPEC-4a
+> **Created**: 2026-02-27
+
+---
+
+## Overview
+
+既存の 3 層アーキテクチャ（CLI → MCP/Core → Storage）に HTTP レイヤーを追加し、
+`server.py`（MCP）と対等な `web.py`（FastAPI）を配置する。サービス配線を
+`_registry.py` に集約し、両モジュールが同一サービスインスタンスを共有する。
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+
+- FastAPI >= 0.115 + uvicorn（daemon thread、tech.md §WebUI 準拠）
+- 単一プロセスモデル: MCP (stdio) が main thread、HTTP が daemon thread
+- ポート戦略: `socket.bind(('', 0))` → OS 割り当て、デフォルト 3000
+- `static/` は hatch `artifacts` で wheel に同梱（tech.md §Distribution 準拠）
+
+### Project Structure (structure.md)
+
+- `web.py` は `server.py` と同階層（structure.md の Layer Architecture 準拠）
+- `_registry.py` は新規だが、既存の module-level getter パターンを集約するだけ
+- `frontend/` と `static/` は structure.md §Repository Layout に定義済み
+
+## Code Reuse Analysis
+
+### 再利用する既存コンポーネント
+
+- **`core/designs.py` (DesignService)**: 4 操作を REST endpoint に直接マッピング
+- **`core/catalog.py` (CatalogService)**: 8 操作を REST endpoint にマッピング
+- **`core/reviews.py` (ReviewService)**: 5 操作を REST endpoint にマッピング
+- **`core/rules.py` (RulesService)**: 2 操作を REST endpoint にマッピング
+- **`models/*`**: Pydantic モデルをそのまま FastAPI のレスポンスモデルとして利用
+- **`server.py` のエラーハンドリングパターン**: `ValueError` → error dict、`None` → not found
+- **`storage/yaml_store.py`**: 間接利用（core/ 経由、web.py から直接呼ばない）
+
+### Integration Points
+
+- **cli.py**: サービス配線先を `server_module` → `_registry` に変更 + daemon thread 起動を追加
+- **server.py**: getter を `_registry` からの import に置き換え（ロジック変更なし）
+- **conftest.py**: テストフィクスチャの配線先を `_registry` に変更
+
+## Architecture
+
+### 全体構成
+
+```
+CLI (cli.py)
+  │
+  ├── _registry.py ← サービスインスタンスの一元管理
+  │     ↑ import        ↑ import
+  │     │               │
+  ├── MCP Server ───────┘
+  │   (server.py)
+  │
+  ├── HTTP Server ──────┘
+  │   (web.py)
+  │     ├── FastAPI app + REST endpoints
+  │     ├── Static file serving (static/)
+  │     └── ThreadedUvicorn (daemon thread)
+  │
+  └── mcp.run()  ← main thread をブロック
+```
+
+### Modular Design Principles
+
+- **Single File Responsibility**: `_registry.py` はサービス参照のみ、`web.py` は
+  HTTP ルーティングのみ。ビジネスロジックは `core/` に閉じる
+- **Component Isolation**: web.py は core/ サービスの getter 呼び出しと
+  HTTP ステータスコードの変換だけを行う薄いレイヤー
+- **Service Layer Separation**: web.py → core/ → storage/ の 3 層。
+  web.py から storage/ への直接アクセス禁止
+- **Utility Modularity**: ID バリデーション (`_validate_design_id` 等) は
+  server.py に既存。web.py では FastAPI の Path パラメータバリデーションを使い、
+  重複ヘルパーを作らない
+
+## Components and Interfaces
+
+### Component 1: `_registry.py`
+
+- **Purpose**: 全サービスインスタンスの一元管理。cli.py で 1 回配線し、
+  server.py と web.py の両方からアクセスする
+- **Interfaces**:
+  ```python
+  # Module-level references (cli.py が設定)
+  design_service: DesignService | None = None
+  catalog_service: CatalogService | None = None
+  review_service: ReviewService | None = None
+  rules_service: RulesService | None = None
+
+  # Typed getters (未初期化時は RuntimeError)
+  def get_design_service() -> DesignService: ...
+  def get_catalog_service() -> CatalogService: ...
+  def get_review_service() -> ReviewService: ...
+  def get_rules_service() -> RulesService: ...
+  ```
+- **Dependencies**: `core/designs.py`, `core/catalog.py`, `core/reviews.py`, `core/rules.py`（型注釈のみ）
+- **Reuses**: server.py の既存 getter パターンをそのまま移植
+
+### Component 2: `web.py`
+
+- **Purpose**: FastAPI アプリケーション。REST API endpoints + 静的ファイル配信 +
+  daemon thread 起動
+- **Interfaces**:
+  ```python
+  app = FastAPI(title="insight-blueprint")
+
+  # Daemon thread 起動（127.0.0.1 固定バインド）
+  def start_server(host: str = "127.0.0.1", port: int = 3000) -> int: ...
+
+  # Path パラメータ: pattern=r"[a-zA-Z0-9_-]+" で ID バリデーション
+  # (既存 server.py の _validate_*_id と同等)
+
+  # REST Endpoints (17 メソッド / 14 URL パターン + health check)
+  # --- Design ---
+  GET    /api/designs                         # ?status= optional
+  POST   /api/designs
+  GET    /api/designs/{design_id}
+  PUT    /api/designs/{design_id}
+  # --- Catalog ---
+  GET    /api/catalog/sources
+  POST   /api/catalog/sources
+  GET    /api/catalog/sources/{source_id}
+  PUT    /api/catalog/sources/{source_id}
+  GET    /api/catalog/sources/{source_id}/schema
+  GET    /api/catalog/search                  # ?q= required, &source_id= optional
+  GET    /api/catalog/knowledge
+  # --- Review ---
+  POST   /api/designs/{design_id}/review
+  GET    /api/designs/{design_id}/comments
+  POST   /api/designs/{design_id}/comments
+  POST   /api/designs/{design_id}/knowledge
+  # --- Rules ---
+  GET    /api/rules/context
+  GET    /api/rules/cautions                  # ?table_names= required
+  # --- Health ---
+  GET    /api/health                          # → {status, version}
+  ```
+- **Dependencies**: `_registry.py`（サービスアクセス）、`fastapi`、`uvicorn`
+- **Reuses**: server.py のエラーハンドリングパターンを HTTP ステータスコードに変換
+- **Query パラメータ設計**:
+  - `GET /api/catalog/search`: `q` (必須) + `source_id` (任意)。サービスの
+    `search(query)` 呼び出し後、`source_id` 指定時は結果を post-filter
+  - `GET /api/rules/cautions`: `table_names` (必須、カンマ区切り)。
+    requirements.md の `design_id` パラメータは v1 では未使用（サービス契約が
+    `suggest_cautions(table_names)` のみのため）。SPEC-4b でフロントエンドが
+    design からテーブル名を抽出して `table_names` に渡す想定
+
+### Component 3: `ThreadedUvicorn`（web.py 内クラス）
+
+- **Purpose**: daemon thread で uvicorn を起動する。signal handler を無効化し、
+  stdout への出力を防ぐ（MCP stdio と競合するため）
+- **Interfaces**:
+  ```python
+  class ThreadedUvicorn(uvicorn.Server):
+      def install_signal_handlers(self) -> None:
+          pass  # main thread でのみ有効なため無効化
+  ```
+- **Dependencies**: `uvicorn`
+- **設計根拠**: uvicorn 0.13.0+ は非 main thread で自動スキップするが、
+  明示的な override が安全。`log_level="warning"` + `access_log=False` で
+  stdout 汚染を完全防止
+
+### Component 4: `frontend/` scaffold
+
+- **Purpose**: SPEC-4b への引き渡し用 React プロジェクト最小構成
+- **Interfaces**: `npm run build` → `src/insight_blueprint/static/` に出力
+- **Dependencies**: React 19, Vite 6, Tailwind CSS, shadcn/ui
+- **構成**:
+  ```
+  frontend/
+  ├── package.json
+  ├── vite.config.ts      # outDir: '../src/insight_blueprint/static'
+  ├── tailwind.config.ts
+  ├── tsconfig.json
+  ├── index.html
+  └── src/
+      └── main.tsx         # placeholder
+  ```
+
+### Component 5: CLI 統合（cli.py 変更）
+
+- **Purpose**: サービス配線 + HTTP サーバー起動 + ブラウザ自動オープン（FR-11）
+- **起動シーケンス**:
+  ```python
+  # 1. _registry にサービス配線
+  import insight_blueprint._registry as registry
+  registry.design_service = DesignService(project_path)
+  # ... 他サービスも同様
+
+  # 2. HTTP サーバー起動（daemon thread）
+  from insight_blueprint.web import start_server
+  port = start_server(host="127.0.0.1", port=3000)
+  url = f"http://127.0.0.1:{port}"
+  print(f"WebUI: {url}", file=sys.stderr)
+
+  # 3. ブラウザ自動起動（--headless でない場合）
+  if not headless:
+      threading.Timer(1.5, webbrowser.open, args=[url]).start()
+
+  # 4. MCP サーバー起動（main thread ブロック）
+  mcp.run()
+  ```
+- **`start_server()` のレディネス保証**:
+  `ThreadedUvicorn.started` フラグが `True` になるまで polling
+  （`while not server.started: time.sleep(1e-3)`）してから port を返す
+- **CORS 設定**:
+  ```python
+  app.add_middleware(
+      CORSMiddleware,
+      allow_origins=["http://localhost:*", "http://127.0.0.1:*"],
+      allow_methods=["*"],
+      allow_headers=["*"],
+  )
+  ```
+
+### Component 6: ビルドパイプライン（FR-14, FR-16）
+
+- **Purpose**: フロントエンドビルド → wheel 同梱の自動化
+- **pyproject.toml 変更**:
+  ```toml
+  # 依存追加 (FR-16)
+  dependencies = [
+      # ... 既存 ...
+      "fastapi>=0.115",
+      "uvicorn[standard]",
+  ]
+
+  [project.optional-dependencies]
+  dev = [
+      # ... 既存 ...
+      "httpx>=0.27",
+  ]
+
+  # hatch artifacts (gitignore 対象の static/ を wheel に含める)
+  [tool.hatch.build.targets.wheel]
+  artifacts = ["src/insight_blueprint/static/**"]
+
+  # poe タスク (FR-14)
+  [tool.poe.tasks.build-frontend]
+  shell = "cd frontend && npm install && npm run build"
+
+  [tool.poe.tasks.build]
+  sequence = ["build-frontend", {shell = "uv build"}]
+  ```
+
+## Data Models
+
+SPEC-4a では新規データモデルを作成しない。既存の Pydantic モデルをそのまま利用する。
+
+### FastAPI リクエストモデル（web.py 内で定義）
+
+```python
+class CreateDesignRequest(BaseModel):
+    title: str
+    hypothesis_statement: str
+    hypothesis_background: str
+    parent_id: str | None = None
+    theme_id: str = "DEFAULT"
+    metrics: dict | None = None
+    explanatory: list[dict] | None = None
+    chart: list[dict] | None = None
+    next_action: dict | None = None
+
+class AddCommentRequest(BaseModel):
+    comment: str
+    status: str
+    reviewer: str = "analyst"
+
+class AddSourceRequest(BaseModel):
+    source_id: str
+    name: str
+    type: str
+    description: str
+    connection: dict
+    columns: list[dict] | None = None
+    tags: list[str] | None = None
+
+class SaveKnowledgeRequest(BaseModel):
+    entries: list[dict]
+```
+
+### レスポンス形式
+
+MCP ツールと同じ JSON 構造を返す（`model.model_dump(mode="json")`）。
+HTTP ステータスコードで成否を表現し、エラー時は FR-8 契約に準拠した
+`{"error": str, "detail"?: str}` 形式で返す。
+
+### エラーレスポンス統一ハンドラー
+
+FastAPI のデフォルト `HTTPException` は `{"detail": ...}` 形式だが、
+FR-8 は `{"error": ...}` を要求する。カスタム exception handler で変換する:
+
+```python
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request, exc):
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": exc.detail},
+    )
+```
+
+## Error Handling
+
+### MCP → HTTP のエラーマッピング
+
+| server.py パターン | web.py 変換 |
+|-------------------|-------------|
+| `return {"error": str(e)}` (ValueError) | `raise HTTPException(400, detail=str(e))` |
+| `if result is None: return {"error": "not found"}` | `raise HTTPException(404, detail="...")` |
+| `if err := _validate_id(id): return err` | `Path(pattern=r"[a-zA-Z0-9_-]+")` で 422 自動返却 |
+| 予期しない例外 | グローバル exception handler → 500 |
+
+### Error Scenarios
+
+1. **サービス未初期化**
+   - Handling: `_registry.get_*_service()` が `RuntimeError` → グローバル handler が 500
+   - User Impact: `{"error": "Internal server error"}`
+
+2. **デザイン未存在**
+   - Handling: service が `None` 返却 → endpoint が 404
+   - User Impact: `{"error": "Design 'xxx' not found"}`
+
+3. **無効なステータス遷移**
+   - Handling: service が `ValueError` → endpoint が 400
+   - User Impact: `{"error": "Design must be in 'active' status to submit for review"}`
+
+3a. **無効な ID フォーマット**
+   - Handling: `Path(pattern=...)` が 422 自動返却
+   - User Impact: FastAPI 標準の validation error レスポンス
+
+4. **ポート競合**
+   - Handling: `start_server()` が `socket.bind(('', 0))` にフォールバック
+   - User Impact: stderr にフォールバックポート番号を出力
+
+5. **static/ 未配置**
+   - Handling: StaticFiles mount が 404 を返す
+   - User Impact: ブラウザに 404 表示（開発中の正常動作）
+
+6. **予期しない例外**
+   - Handling: FastAPI グローバル exception handler
+   - User Impact: `{"error": "Internal server error"}`（stack trace 非公開、
+     ValueError メッセージもそのまま返さず汎用化する場合は将来検討）
+
+## Known Constraints
+
+### スレッド安全性
+
+MCP (main thread) と HTTP (daemon thread) が同一サービスインスタンスを共有する。
+YAML ファイルの read-modify-write（`update_design`, `save_review_comment` 等）に
+ファイルロックは実装しない。
+
+**根拠**: v1 は localhost シングルユーザー想定であり、MCP と HTTP の同時書き込みは
+実用上発生しない（ユーザーが MCP とブラウザで同時に同じデザインを更新する操作は想定外）。
+
+**将来対応**: マルチユーザー対応時にファイルロック or atomic write を導入する。
+
+### _registry の再配線禁止
+
+`_registry` のサービス参照は `cli.py` で起動時に 1 回だけ設定する。
+ランタイム中の再配線は禁止（CPython の module-level 代入はアトミックだが、
+サービス状態の一貫性を保証できないため）。
+
+## Testing Strategy
+
+### Unit Testing
+
+**`tests/test_registry.py`** — _registry.py のテスト
+- 未初期化時の `RuntimeError` 送出
+- 設定後の getter 正常動作
+- 各テスト後のサービス参照リセット（autouse fixture）
+
+**`tests/test_web.py`** — REST endpoint のテスト（httpx `TestClient` 使用）
+- 全 17 endpoint の正常系・異常系
+- エラーレスポンスの HTTP ステータスコード検証
+- エラーレスポンス body が `{"error": ...}` 形式であることの検証
+- Path パラメータの ID バリデーション（不正 ID → 422）
+- `TestClient` は uvicorn なしで FastAPI app を直接テスト
+- テストフィクスチャ:
+  ```python
+  @pytest.fixture
+  def client(tmp_path: Path) -> TestClient:
+      init_project(tmp_path)
+      registry.design_service = DesignService(tmp_path)
+      registry.catalog_service = CatalogService(tmp_path)
+      registry.review_service = ReviewService(tmp_path, registry.design_service)
+      registry.rules_service = RulesService(tmp_path, registry.catalog_service)
+      from insight_blueprint.web import app
+      return TestClient(app)
+  ```
+
+### Integration Testing
+
+**既存テストのリグレッション確認**
+- `_registry` への移行後、既存 183 テスト全通過を確認
+- `tests/test_server.py` の autouse fixture を `_registry` 向けに更新
+- `tests/conftest.py` の配線を `_registry` 経由に変更
+
+### End-to-End Testing
+
+**`tests/test_web_integration.py`** — フルフロー統合テスト
+- `TestClient` 経由で Design 作成 → レビュー提出 → コメント → 知識抽出の一連フローを検証
+- `start_server()` のポート取得と health check レスポンスの検証
+  （実際の daemon thread 起動テスト）
+- `start_server()` のポート競合フォールバック検証
+
+**`tests/test_web_cli.py`** — CLI 統合テスト（FR-11）
+- `--headless=True` 時にブラウザが開かないことの検証（`webbrowser.open` を mock）
+- `--headless=False`（デフォルト）時に `threading.Timer` が設定されることの検証
+- stderr への WebUI URL 出力検証
+
+### Security Testing
+
+- `start_server()` が `127.0.0.1` にバインドすることの検証
+  （`0.0.0.0` でないことの確認）
+- CORS middleware が localhost origin のみ許可することの検証
+
+### Build Pipeline Testing
+
+- `poe build-frontend` の実行と `static/` への出力確認
+  （CI 環境に Node.js が必要。ローカル手動検証でも可）
+- `uv build` で生成した wheel 内に static ファイルが含まれることを確認
+
+### スレッド安全性に関するテスト方針
+
+v1 はシングルユーザー localhost 想定のため、MCP + HTTP 同時書き込みの
+並行テストは実施しない（Known Constraints 参照）。将来マルチユーザー対応時に追加する。

--- a/.spec-workflow/specs/SPEC-4a/requirements.md
+++ b/.spec-workflow/specs/SPEC-4a/requirements.md
@@ -1,0 +1,230 @@
+# SPEC-4a: webui-backend — Requirements
+
+> **Spec ID**: SPEC-4a
+> **Feature Name**: webui-backend
+> **Status**: draft
+> **Created**: 2026-02-26
+> **Depends On**: SPEC-1, SPEC-2, SPEC-3
+
+---
+
+## Introduction
+
+既存の MCP ツール機能を REST API として公開する HTTP バックエンドを追加する。
+サービス配線の共有レジストリ化、FastAPI アプリ（14 URL / 17 メソッド）、
+uvicorn daemon thread、フロントエンドの wheel 同梱ビルドパイプラインを含む。
+
+## Alignment with Product Vision
+
+- **MCP + WebUI によるEDA支援**: REST API が全操作を HTTP 経由で公開し、
+  ブラウザダッシュボード（SPEC-4b）から同じデータにアクセス可能にする
+- **Zero-install (`uvx insight-blueprint`)**: hatch artifacts + poe タスクで
+  ビルド済みフロントエンドを wheel に同梱。エンドユーザーに Node.js 不要
+- **Roadmap 進行**: 旧 SPEC-4 を Backend/Frontend に2分割。SPEC-4b はこの
+  REST API に依存する
+
+## Requirements
+
+### Requirement 1: Service Registry
+
+**User Story:** 開発者として、MCP server (`server.py`) と HTTP server (`web.py`)
+の両方が同じサービスインスタンスを共有できるよう、配線を一元管理したい。
+
+**FR-1: Registry モジュール**
+- `src/insight_blueprint/_registry.py` を新規作成
+- module-level 変数: `design_service`, `catalog_service`, `review_service`,
+  `rules_service`（全て初期値 `None`）
+- typed getter: `get_design_service()` 等、未初期化時は `RuntimeError` を送出
+
+**FR-2: server.py の移行**
+- `server.py` の 4 つの module-level 変数と getter を削除
+- 全 MCP tool 関数を `_registry.get_*_service()` 経由に変更
+
+**FR-3: cli.py の配線変更**
+- `_registry` への一括配線に変更:
+  ```python
+  import insight_blueprint._registry as registry
+  registry.design_service = DesignService(project_path)
+  ```
+
+#### Acceptance Criteria
+
+1. WHEN `_registry.get_design_service()` を配線前に呼ぶ THEN `RuntimeError` が発生する
+2. WHEN `cli.py` が `_registry` に配線する THEN `server.py` と `web.py` の両方から同一インスタンスにアクセスできる
+3. WHEN 既存テストを実行する THEN 全 183 テストが通る（import パス変更を除き修正不要）
+4. WHEN `_registry.py` を確認する THEN サービス参照と getter のみで、ビジネスロジックを含まない
+
+### Requirement 2: REST API Endpoints
+
+**User Story:** フロントエンド開発者として、全操作を REST API で利用したい。
+
+**FR-4: Design Endpoints**
+- `GET /api/designs` — 一覧（`?status=` フィルタ任意）→ `{designs, count}`
+- `POST /api/designs` — 作成 → 201 + `{design, message}`
+- `GET /api/designs/{design_id}` — 取得 → `AnalysisDesign` or 404
+- `PUT /api/designs/{design_id}` — 更新 → `AnalysisDesign` or 404
+
+**FR-5: Catalog Endpoints**
+- `GET /api/catalog/sources` — ソース一覧 → `{sources, count}`
+- `POST /api/catalog/sources` — ソース追加 → 201 + `{source, message}`
+- `GET /api/catalog/sources/{source_id}` — 取得 → `DataSource` or 404
+- `PUT /api/catalog/sources/{source_id}` — 更新 → `DataSource` or 404
+- `GET /api/catalog/sources/{source_id}/schema` — スキーマ取得 → `{source_id, columns}` or 404
+- `GET /api/catalog/search?q={query}` — FTS5 検索（`&source_id=` 任意）→ `{query, results, count}`
+- `GET /api/catalog/knowledge` — ドメイン知識一覧 → `{entries, count}`
+
+**FR-6: Review Endpoints**
+- `POST /api/designs/{design_id}/review` — レビュー提出 → `{design_id, status, message}` or error
+- `GET /api/designs/{design_id}/comments` — コメント一覧 → `{design_id, comments, count}`
+- `POST /api/designs/{design_id}/comments` — コメント追加 → `{comment_id, status_after, message}` or error
+- `POST /api/designs/{design_id}/knowledge` — 知識抽出・保存
+  - body なし → preview（抽出のみ、保存しない）
+  - `{entries: [...]}` あり → 確認済みエントリを保存
+
+**FR-7: Rules Endpoints**
+- `GET /api/rules/context` — 蓄積されたドメイン知識・ルールの一覧取得
+  - catalog 知識（`catalog/knowledge/*.yaml`）と review 抽出知識（`extracted_knowledge.yaml`）を集約して返す
+  - Returns: `{sources, knowledge_entries, rules, total_sources, total_knowledge, total_rules}`
+  - Maps to: `RulesService.get_project_context()`
+- `GET /api/rules/cautions?design_id={id}` — 注意事項の提案（`&table_names=` 任意）
+  - 指定テーブルに関連する注意事項を `affects_columns` マッチングで返す
+
+**FR-8: エラーレスポンス**
+- 統一フォーマット: `{error: str, detail?: str}`
+- status code: 200/201/400/404/500
+- `ValueError` → 400、`None` 返却 → 404、stack trace は公開しない
+
+#### Acceptance Criteria
+
+1. WHEN `GET /api/designs` THEN 全デザインが count 付きで返る
+2. WHEN `POST /api/designs` + valid body THEN 201 で作成される
+3. WHEN `GET /api/designs/nonexistent` THEN 404 + `{error}` が返る
+4. WHEN `GET /api/catalog/search?q=keyword` THEN FTS5 検索結果が返る
+5. WHEN `POST /api/designs/{id}/review` を非 active なデザインに THEN 400 が返る
+6. WHEN `POST /api/designs/{id}/comments` + 無効な status THEN 400 が返る
+7. WHEN `GET /api/rules/context` THEN 全ソースの集約知識が返る
+8. WHEN `GET /api/rules/cautions?table_names=X,Y` THEN 該当する注意事項が返る
+9. WHEN 予期しない例外が発生 THEN 500 + `{error: "Internal server error"}`（stack trace なし）
+10. WHEN `POST /api/designs/{id}/knowledge` + body なし THEN 抽出 preview が返る
+11. WHEN `POST /api/designs/{id}/knowledge` + `{entries}` THEN 保存されて確認が返る
+
+### Requirement 3: HTTP Server & Process Model
+
+**User Story:** データサイエンティストとして、`insight-blueprint` 起動時に
+WebUI が自動で立ち上がり、ブラウザですぐにダッシュボードを開きたい。
+
+**FR-9: FastAPI アプリケーション**
+- `src/insight_blueprint/web.py` に FastAPI アプリを作成
+- `static/` から静的ファイル配信（React ビルド成果物）
+- `127.0.0.1` のみにバインド（外部アクセス不可）
+- localhost 向け CORS middleware を設定
+
+**FR-10: Daemon Thread 起動**
+- `web.py` が `start_server(port: int = 3000) -> int` を公開:
+  1. 指定ポートへのバインドを試行。失敗時は `socket.bind(('', 0))` で OS 自動割り当て
+  2. `daemon=True` スレッドで uvicorn を起動
+  3. 実際のポート番号を返す
+
+**FR-11: CLI 統合**
+- `cli.py` でサービス配線後、`mcp.run()` 前に `start_server()` を呼ぶ
+- `--headless=False`（デフォルト）: `threading.Timer(1.5, webbrowser.open)` でブラウザ起動
+- `--headless=True`: ブラウザ起動を抑制
+- WebUI URL を stderr に出力（stdout は MCP stdio 専用）
+
+**FR-12: Health Check**
+- `GET /api/health` → `{status: "ok", version: str}`
+- サービス初期化不要（常時応答可能）
+
+#### Acceptance Criteria
+
+1. WHEN `start_server(3000)` + port 3000 空き THEN port 3000 で起動
+2. WHEN `start_server(3000)` + port 3000 使用中 THEN OS 割り当てポートで起動
+3. WHEN `start_server()` 完了後 THEN `GET /api/health` が応答する
+4. WHEN `--headless` なし THEN 1.5 秒後にブラウザが開く
+5. WHEN `--headless` あり THEN ブラウザは開かない
+6. WHEN MCP server 終了 THEN daemon thread も自動終了
+7. WHEN `static/` にファイルがある THEN `GET /` で `index.html` が返る
+8. WHEN `static/` が空（開発中）THEN `GET /` は 404（クラッシュしない）
+
+### Requirement 4: Build Pipeline
+
+**User Story:** 開発者として、React フロントエンドを Python wheel に同梱する
+ビルドパイプラインを整備し、エンドユーザーに Node.js を要求しない配布を実現したい。
+
+**FR-13: Hatch Artifacts 設定**
+- `pyproject.toml` で `src/insight_blueprint/static/**` を wheel に含める
+- `static/` は `.gitignore` 対象（ビルド成果物のみ）
+
+**FR-14: Poe Build タスク**
+- `build-frontend`: `cd frontend && npm install && npm run build`
+  （出力先: `src/insight_blueprint/static/`）
+- `build`: `build-frontend` → `uv build`（フルビルド）
+
+**FR-15: Frontend Scaffold**
+- `frontend/` に最小構成を作成:
+  - `package.json`（React 19, Vite 6, Tailwind CSS, shadcn/ui）
+  - `vite.config.ts`（`outDir: '../src/insight_blueprint/static'`）
+  - `index.html` + `src/main.tsx`（プレースホルダ表示）
+- SPEC-4b への引き渡しポイント
+
+**FR-16: 依存追加**
+- `fastapi>=0.115`, `uvicorn[standard]` を dependencies に追加
+- `httpx>=0.27` を dev dependencies に追加（TestClient 用）
+
+#### Acceptance Criteria
+
+1. WHEN `poe build-frontend` 実行 THEN `src/insight_blueprint/static/` にビルド成果物が出力される
+2. WHEN `poe build-frontend` 後に `uv build` THEN wheel に static ファイルが含まれる
+3. WHEN ビルド済み wheel から `uvx insight-blueprint` THEN 静的ファイルが配信される
+4. WHEN `frontend/` を確認 THEN 有効な Vite + React プロジェクトがある
+5. WHEN `poe build` THEN frontend ビルド → Python パッケージビルドの順で実行される
+6. WHEN Node.js なしで wheel をインストール THEN ビルド済み static が利用可能
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+
+- **Single Responsibility**: `_registry.py` はサービス参照のみ、`web.py` は HTTP ルーティングのみ（薄いレイヤー）
+- **3層分離**: web.py → core/ → storage/。web.py から storage/ への直接アクセス禁止
+- **パターン再利用**: server.py と同じ getter ベースのサービスアクセスパターン
+- 全関数に型注釈必須（`ty check` 通過）
+- `ruff check` 通過、`web.py` と `_registry.py` のテストカバレッジ 80% 以上
+
+### Performance
+
+- 全 REST endpoint: 100ms 以内（localhost、シングルユーザー）
+- `GET /api/catalog/search`: 200ms 以内（100 ソースまで）
+- `start_server()`: 2 秒以内に完了
+
+### Security
+
+- `127.0.0.1` バインドのみ（外部アクセス不可）
+- v1 は認証不要（localhost シングルユーザー）
+- エラーレスポンスに内部パス・stack trace を含めない
+- CORS は localhost origin のみ許可
+
+### Reliability
+
+- `daemon=True` でメインスレッド終了時に自動停止
+- ポート競合時は OS 割り当てにフォールバック（クラッシュしない）
+- `static/` 未配置時は 404（クラッシュしない）
+- サービス未初期化時は全 endpoint が 500 + 明確なエラーを返す
+- 既存 SPEC-1/2/3 テスト全通過（リグレッションなし）
+
+### Usability
+
+- 起動時に WebUI URL を stderr に出力
+- デフォルトでブラウザ自動起動（`--headless` で抑制可）
+- `poe build-frontend` / `poe build` は Node.js 未インストール時に明確なエラー
+- 全 endpoint で統一 JSON フォーマット
+
+## Out of Scope
+
+- WebSocket（v1 はポーリングで十分）
+- 認証・認可（localhost シングルユーザー）
+- API バージョニング（v1 のみ）
+- Rate limiting
+- OpenAPI ドキュメントのカスタマイズ（FastAPI 自動生成で十分）
+- フロントエンド実装（scaffold 以上は SPEC-4b）
+- HTTPS/TLS（localhost のみ）
+- API ページネーション（データセットが小規模）

--- a/.spec-workflow/specs/SPEC-4a/tasks.md
+++ b/.spec-workflow/specs/SPEC-4a/tasks.md
@@ -1,0 +1,325 @@
+# SPEC-4a: webui-backend — Tasks
+
+> **Spec ID**: SPEC-4a
+> **Status**: draft
+> **Created**: 2026-02-27
+> **Depends On**: SPEC-1, SPEC-2, SPEC-3
+
+---
+
+## Dependency Graph
+
+```
+1.1 ──→ 1.2 ──→ 2.1 ──→ 2.2 ──→ 2.3 ──→ 2.4 ──→ 2.5 ──┐
+                  ↓                                        ↓
+                 3.1 ──→ 3.2 ────────────────────────→ 5.1
+
+4.1 (独立: 他タスクと並列可)
+```
+
+---
+
+## 全体完了基準
+
+| # | 基準 | 指標 |
+|---|------|------|
+| C1 | 全タスク完了 | 11/11 tasks marked `[x]` |
+| C2 | 新規テスト通過 | 72 tests green |
+| C3 | リグレッションなし | 既存 260 テスト全通過 |
+| C4 | 品質ゲート通過 | `poe all` (ruff + ty + pytest) exit 0 |
+| C5 | REST API 動作 | 18 endpoints (17 + health) 全応答 |
+| C6 | 統合フロー通過 | `test_full_flow_create_to_knowledge` green |
+
+## 全体確認手順
+
+1. **品質ゲート**
+   ```bash
+   poe all
+   ```
+   exit 0、ruff 違反ゼロ、ty エラーゼロ、全テスト通過
+
+2. **テスト数**
+   ```bash
+   uv run pytest --co -q | tail -1
+   ```
+   332 tests collected (260 既存 + 72 新規)
+
+3. **カバレッジ**
+   ```bash
+   uv run pytest --cov=src/insight_blueprint/_registry --cov=src/insight_blueprint/web --cov-report=term-missing
+   ```
+   `_registry.py` と `web.py` 各 80% 以上
+
+---
+
+- [x] 1.1 `_registry.py` 新規作成 + テスト
+  - File: `src/insight_blueprint/_registry.py` (新規), `tests/test_registry.py` (新規)
+  - module-level 変数 4 つ（初期値 `None`）と typed getter 4 つを実装
+  - 未初期化時に `RuntimeError` を送出
+  - module 純度テスト: getter 以外の関数・クラスが存在しないことを検証
+  - TDD: 9 テストを先に書く（Red → Green）
+  - Purpose: サービス配線の一元管理モジュール。server.py と web.py の共有基盤
+  - _Leverage: `server.py` 既存 getter パターン（`_design_service`, `get_design_service()` 等）_
+  - _Requirements: FR-1, R1-AC1, R1-AC2, R1-AC4_
+  - **完了基準**:
+    - 4 つの module-level 変数と 4 つの getter が存在する
+    - 未初期化 getter が `RuntimeError` を送出する（4 getter 全て）
+    - 配線後の getter が同一インスタンスを返す（4 getter 全て）
+    - module に getter 以外の関数・クラスが存在しない
+    - 9 テスト全通過
+  - **確認手順**:
+    ```bash
+    uv run pytest tests/test_registry.py -v
+    ```
+    9 passed を確認
+    ```bash
+    uv run ruff check src/insight_blueprint/_registry.py && uv run ty check src/insight_blueprint/_registry.py
+    ```
+    違反ゼロ
+  - _Prompt: Role: Python Developer with module design expertise | Task: Create `_registry.py` with 4 module-level service references (initial None) and 4 typed getters raising RuntimeError when uninitialized. Write 9 tests first (TDD): 4 uninitialized, 4 after-wiring, 1 module purity | Restrictions: No business logic. Use TYPE_CHECKING for service type imports. Only references + getters | Success: 9 tests pass, ruff + ty clean_
+
+- [x] 1.2 server.py / cli.py / conftest.py の `_registry` 移行
+  - File: `src/insight_blueprint/server.py` (変更), `src/insight_blueprint/cli.py` (変更), `tests/conftest.py` (変更), `tests/test_server.py` (変更)
+  - `server.py`: module-level 変数 4 つと getter 4 つを削除。全 MCP tool を `_registry.get_*_service()` 経由に変更
+  - `cli.py`: 配線先を `server._service` → `_registry.service` に変更
+  - `conftest.py`: shared fixture の配線先を `_registry` 経由に変更
+  - `test_server.py`: `_reset_service` fixture を `_registry` リセットに更新
+  - Purpose: サービス配線を `_registry` に一本化し、web.py からも同一インスタンスにアクセス可能にする
+  - _Leverage: 既存 `server._design_service` → `_registry.get_design_service()` の 1:1 置換_
+  - _Requirements: FR-2, FR-3, R1-AC2, R1-AC3_
+  - **完了基準**:
+    - `server.py` から module-level サービス変数と getter が全て削除されている
+    - `server.py` の全 MCP tool が `_registry.get_*_service()` を使用
+    - `cli.py` が `_registry` 経由でサービスを配線
+    - 既存 260 テスト全通過（リグレッションなし）
+  - **確認手順**:
+    ```bash
+    uv run pytest -v
+    ```
+    260 passed を確認
+    ```bash
+    grep -c "get_design_service\|get_catalog_service\|get_review_service\|get_rules_service" src/insight_blueprint/server.py
+    ```
+    `_registry` 経由の getter 呼び出しが存在することを確認
+    ```bash
+    grep -c "_design_service\s*=" src/insight_blueprint/server.py
+    ```
+    module-level 代入が 0 件であることを確認
+  - _Prompt: Role: Python Developer with refactoring expertise | Task: Migrate server.py from module-level service references to _registry.get_*_service(). Update cli.py wiring to _registry. Update conftest.py and test_server.py fixtures to reset _registry. All 260 existing tests must pass | Restrictions: Logic changes forbidden — import path changes only. Atomic migration (all files together) | Success: 260 existing tests pass, no module-level service references in server.py_
+
+- [x] 2.1 FastAPI app 骨格 + 依存追加 + health check + error handler + CORS
+  - File: `src/insight_blueprint/web.py` (新規), `pyproject.toml` (変更), `tests/test_web.py` (新規, 部分)
+  - `pyproject.toml`: `fastapi>=0.115`, `uvicorn[standard]` を dependencies に、`httpx>=0.27` を dev dependencies に追加
+  - `web.py`: FastAPI app、CORS middleware（localhost only）、custom HTTPException handler（`{"error": ...}` 形式）、`GET /api/health`
+  - Pydantic request models 定義: `CreateDesignRequest`, `AddCommentRequest`, `AddSourceRequest`, `SaveKnowledgeRequest`
+  - `test_web.py`: `_reset_registry` autouse fixture、`web_client` yield fixture
+  - テスト: health 2 件 + error format 4 件 + CORS 2 件 = 8 件
+  - Purpose: REST API 基盤を構築し、エラーハンドリングとセキュリティの土台を固める
+  - _Leverage: server.py のエラーパターン（ValueError → 400, None → 404）_
+  - _Requirements: FR-8, FR-9, FR-12, FR-16, R2-AC9, R3-AC3_
+  - **完了基準**:
+    - `fastapi`, `uvicorn[standard]`, `httpx` が依存に追加されている
+    - `GET /api/health` が `{"status": "ok", "version": str}` を返す
+    - health check がサービス未初期化でも 200 を返す
+    - エラーレスポンスが `{"error": ...}` 形式（`{"detail": ...}` でない）
+    - CORS が localhost origin のみ許可し、外部 origin を拒否する
+    - 8 テスト全通過
+  - **確認手順**:
+    ```bash
+    uv run pytest tests/test_web.py -v -k "health or error or cors"
+    ```
+    8 passed を確認
+    ```bash
+    uv run python -c "from insight_blueprint.web import app; print(app.title)"
+    ```
+    import 成功を確認
+  - _Prompt: Role: Python Developer with FastAPI expertise | Task: Create web.py with FastAPI app, CORS middleware (localhost only), custom HTTPException handler converting detail to error format, health check endpoint returning status+version, Pydantic request models. Add dependencies to pyproject.toml. Write fixtures (\_reset\_registry autouse, web\_client yield with TestClient context manager) and 8 tests | Restrictions: Health check must work without service init. Error handler must convert ALL HTTPException. CORS must reject non-localhost | Success: 8 tests pass, health responds without services, errors use error format_
+
+- [x] 2.2 Design endpoints 実装 + テスト
+  - File: `src/insight_blueprint/web.py` (変更), `tests/test_web.py` (変更)
+  - 4 endpoints: `GET /api/designs`、`POST /api/designs`、`GET /api/designs/{design_id}`、`PUT /api/designs/{design_id}`
+  - Path パラメータ: `design_id: str = Path(pattern=r"[a-zA-Z0-9_-]+")`
+  - `GET` は `?status=` フィルタ任意。`POST` は 201 を返す
+  - TDD: 10 テスト (#1-10)
+  - Purpose: Design CRUD を REST API で公開
+  - _Leverage: `DesignService.list_designs()`, `create_design()`, `get_design()`, `update_design()`_
+  - _Requirements: FR-4, R2-AC1, R2-AC2, R2-AC3_
+  - **完了基準**:
+    - 4 Design endpoints が正常動作
+    - 一覧が `{designs, count}` 形式、`?status=` フィルタが動作
+    - 作成が 201 + `{design, message}` で返る
+    - 不正 ID → 422、存在しない ID → 404 + `{"error": ...}`
+    - 10 テスト全通過
+  - **確認手順**:
+    ```bash
+    uv run pytest tests/test_web.py -v -k "test_list_designs or test_create_design or test_get_design or test_update_design"
+    ```
+    10 passed を確認
+  - _Prompt: Role: Python Developer with FastAPI REST API expertise | Task: Implement 4 Design endpoints: list (?status filter), create (201), get, update. Path validation: Path(pattern=r"[a-zA-Z0-9_-]+"). Write 10 tests per TDD | Restrictions: Thin layer — delegate to _registry.get_design_service(). ValueError→400, None→404 | Success: 10 tests pass_
+
+- [x] 2.3 Catalog endpoints 実装 + テスト
+  - File: `src/insight_blueprint/web.py` (変更), `tests/test_web.py` (変更)
+  - 7 endpoints: sources CRUD + schema + search + knowledge 一覧
+  - `GET /api/catalog/search`: `q` 必須、`source_id` 任意（service 呼び出し後に post-filter）
+  - TDD: 17 テスト (#11-27)
+  - Purpose: Data Catalog 操作を REST API で公開
+  - _Leverage: `CatalogService.list_sources()`, `add_source()`, `get_source()`, `update_source()`, `get_schema()`, `search()`, `get_knowledge()`_
+  - _Requirements: FR-5, R2-AC4_
+  - **完了基準**:
+    - 7 Catalog endpoints が正常動作
+    - search が `q` 必須 + `source_id` post-filter で動作
+    - 重複 source 追加 → 400、必須フィールド欠落 → 422
+    - 17 テスト全通過
+  - **確認手順**:
+    ```bash
+    uv run pytest tests/test_web.py -v -k "source or schema or search or test_get_knowledge_list"
+    ```
+    17 passed を確認
+  - _Prompt: Role: Python Developer with FastAPI REST API expertise | Task: Implement 7 Catalog endpoints: list sources, add (201), get, update, get schema, search (?q required, &source_id post-filter), get knowledge. Write 17 tests per TDD | Restrictions: search source_id is post-filter after service.search(). Duplicate source→400. Missing fields→422 via Pydantic | Success: 17 tests pass_
+
+- [x] 2.4 Review endpoints 実装 + テスト
+  - File: `src/insight_blueprint/web.py` (変更), `tests/test_web.py` (変更)
+  - 4 endpoints: review 提出 + comments 一覧・追加 + knowledge (preview/save)
+  - knowledge: body なし → preview（抽出のみ）、`{entries}` あり → save（永続化）
+  - TDD: 12 テスト (#28-39)
+  - Purpose: Review workflow を REST API で公開
+  - _Leverage: `ReviewService.submit_for_review()`, `list_comments()`, `save_review_comment()`, `extract_domain_knowledge()`, `save_extracted_knowledge()`_
+  - _Requirements: FR-6, R2-AC5, R2-AC6, R2-AC10, R2-AC11_
+  - **完了基準**:
+    - 4 Review endpoints が正常動作
+    - 非 active デザインへの review → 400
+    - 無効 status コメント → 400、存在しない design → 404
+    - knowledge の preview / save が body 有無で正しく分岐
+    - 12 テスト全通過
+  - **確認手順**:
+    ```bash
+    uv run pytest tests/test_web.py -v -k "review or comment or knowledge_preview or knowledge_save or knowledge_not_found or knowledge_invalid"
+    ```
+    12 passed を確認
+  - _Prompt: Role: Python Developer with FastAPI REST API expertise | Task: Implement 4 Review endpoints: submit review, list comments, add comment, knowledge (preview if no body, save if entries body). Write 12 tests per TDD | Restrictions: Non-active to 400, invalid status to 400, not found to 404. Preview must NOT persist. Save persists confirmed entries | Success: 12 tests pass_
+
+- [x] 2.5 Rules endpoints 実装 + テスト
+  - File: `src/insight_blueprint/web.py` (変更), `tests/test_web.py` (変更)
+  - 2 endpoints: `GET /api/rules/context`、`GET /api/rules/cautions?table_names=X,Y`
+  - `table_names` は必須パラメータ（カンマ区切り → list に split）
+  - TDD: 4 テスト (#40-43)
+  - Purpose: ルール・知識集約を REST API で公開
+  - _Leverage: `RulesService.get_project_context()`, `suggest_cautions(table_names)`_
+  - _Requirements: FR-7, R2-AC7, R2-AC8_
+  - **完了基準**:
+    - 2 Rules endpoints が正常動作
+    - context が全ソースの集約知識を返す
+    - cautions が `table_names` でフィルタリング
+    - `table_names` 未指定 → 422
+    - 4 テスト全通過
+  - **確認手順**:
+    ```bash
+    uv run pytest tests/test_web.py -v -k "context or caution"
+    ```
+    4 passed を確認
+  - _Prompt: Role: Python Developer with FastAPI REST API expertise | Task: Implement 2 Rules endpoints: GET /api/rules/context, GET /api/rules/cautions?table_names=X,Y (required, comma-split). Write 4 tests per TDD | Restrictions: table_names required→422 if missing. v1 ignores design_id (service takes table_names only). Thin layer | Success: 4 tests pass_
+
+- [x] 3.1 ThreadedUvicorn + `start_server()` + static files + テスト
+  - File: `src/insight_blueprint/web.py` (変更), `tests/test_web_integration.py` (新規)
+  - `ThreadedUvicorn(uvicorn.Server)`: `install_signal_handlers` 空実装、`log_level="warning"`, `access_log=False`
+  - `start_server(host, port)`: ポート probe → フォールバック → daemon thread → readiness polling → port 返却
+  - `_server_instance` module-level 参照（テストの shutdown 用）
+  - `StaticFiles` mount（`static/` 存在時のみ）
+  - `_server_lifecycle` fixture: `should_exit = True` で確実停止
+  - テスト: server lifecycle 5 件 + static 2 件 = 7 件 (integration #2-8)
+  - Purpose: HTTP サーバーの daemon thread 起動と静的ファイル配信
+  - _Leverage: design.md Component 3 (ThreadedUvicorn), Component 5 (readiness polling)_
+  - _Requirements: FR-9, FR-10, R3-AC1, R3-AC2, R3-AC3, R3-AC6, R3-AC7, R3-AC8_
+  - **完了基準**:
+    - `start_server(port=0)` が有効なポートを返す
+    - ポート競合時に OS 割り当てポートへフォールバック
+    - 起動後 `GET /api/health` が応答
+    - `should_exit = True` でスレッド終了
+    - `static/index.html` 存在時に `GET /` で配信
+    - `static/` 未配置時に 404（クラッシュしない）
+    - 7 テスト全通過
+  - **確認手順**:
+    ```bash
+    uv run pytest tests/test_web_integration.py -v -k "not full_flow"
+    ```
+    7 passed を確認
+  - _Prompt: Role: Python Developer with uvicorn and threading expertise | Task: Implement ThreadedUvicorn (empty install_signal_handlers, log_level=warning, access_log=False), start_server (port probe→fallback→daemon thread→readiness poll→return port), StaticFiles mount (only if dir exists), _server_lifecycle fixture (should_exit=True cleanup). Write 7 tests | Restrictions: host default "127.0.0.1". socket.bind for probing. Readiness poll via server.started. daemon=True thread. Static mount must not crash when dir missing | Success: 7 tests pass, clean start/stop, no CI port conflicts_
+
+- [x] 3.2 CLI 統合（headless, browser, stderr）+ テスト
+  - File: `src/insight_blueprint/cli.py` (変更), `tests/test_web_cli.py` (新規)
+  - サービス配線後・`mcp.run()` 前に `start_server()` を呼び出し
+  - `--headless` フラグ追加（default False）
+  - ブラウザ起動: `threading.Timer(1.5, webbrowser.open, args=[url]).start()`
+  - WebUI URL を stderr に出力
+  - テスト: 4 件 (CLI #1-4)。`webbrowser.open`, `threading.Timer` を mock
+  - Purpose: CLI 起動時に HTTP サーバーを自動起動し、ブラウザでダッシュボードを開く
+  - _Leverage: design.md Component 5 (CLI 統合シーケンス)_
+  - _Requirements: FR-11, R3-AC4, R3-AC5_
+  - **完了基準**:
+    - `--headless` なしでブラウザ起動（`threading.Timer` 経由）
+    - `--headless` ありでブラウザ非起動
+    - stderr に WebUI URL (`http://127.0.0.1:<port>`) を出力
+    - uvicorn が `127.0.0.1` にバインド（`0.0.0.0` でない）
+    - 4 テスト全通過
+  - **確認手順**:
+    ```bash
+    uv run pytest tests/test_web_cli.py -v
+    ```
+    4 passed を確認
+  - _Prompt: Role: Python Developer with CLI integration expertise | Task: Add --headless flag to cli.py, call start_server() after wiring before mcp.run(), output URL to stderr, conditionally start browser via threading.Timer(1.5). Write 4 tests with mocked webbrowser.open and threading.Timer | Restrictions: stdout reserved for MCP stdio. Default headless=False. Timer 1.5s delay. start_server before mcp.run() | Success: 4 tests pass_
+
+- [x] 4.1 Frontend scaffold + ビルドパイプライン
+  - File: `frontend/` (新規), `pyproject.toml` (変更), `.gitignore` (変更)
+  - `frontend/`: `package.json` (React 19, Vite 6, Tailwind CSS), `vite.config.ts` (`outDir: '../src/insight_blueprint/static'`), `tailwind.config.ts`, `tsconfig.json`, `index.html`, `src/main.tsx` (placeholder)
+  - `pyproject.toml`: hatch `artifacts` 設定 (`src/insight_blueprint/static/**`)、poe `build-frontend` / `build` タスク
+  - `.gitignore`: `src/insight_blueprint/static/` を追加
+  - Purpose: SPEC-4b のフロントエンド開発基盤と wheel 同梱ビルドパイプラインを構築
+  - _Leverage: design.md Component 4 (scaffold), Component 6 (build pipeline)_
+  - _Requirements: FR-13, FR-14, FR-15, R4-AC1〜AC6_
+  - **完了基準**:
+    - `frontend/` に有効な Vite + React プロジェクトが存在
+    - `cd frontend && npm install && npm run build` が成功（Node.js 環境）
+    - ビルド成果物が `src/insight_blueprint/static/` に出力される
+    - `pyproject.toml` に hatch artifacts と poe タスクが設定されている
+    - `static/` が `.gitignore` に含まれている
+  - **確認手順**:
+    ```bash
+    cd frontend && npm install && npm run build && ls ../src/insight_blueprint/static/index.html
+    ```
+    `index.html` の存在を確認
+    ```bash
+    grep -A2 "\[tool.hatch.build.targets.wheel\]" pyproject.toml
+    ```
+    artifacts 設定を確認
+    ```bash
+    grep "static" .gitignore
+    ```
+    `.gitignore` に含まれることを確認
+  - _Prompt: Role: Frontend Developer with Vite + React expertise | Task: Create minimal frontend scaffold: package.json (React 19, Vite 6, Tailwind CSS), vite.config.ts (outDir '../src/insight_blueprint/static'), index.html, src/main.tsx (placeholder). Add hatch artifacts and poe tasks to pyproject.toml. Add static/ to .gitignore | Restrictions: Minimal scaffold — real implementation is SPEC-4b. outDir must point to static/. poe build = build-frontend then uv build | Success: npm run build works, static/index.html produced, pyproject.toml configured_
+
+- [x] 5.1 Full flow 統合テスト + リグレッション確認
+  - File: `tests/test_web_integration.py` (変更)
+  - `test_full_flow_create_to_knowledge`: Design 作成 → activate → review → comment → knowledge preview → save → rules context 検証の全フロー
+  - 全 332 テスト（260 既存 + 72 新規）通過を確認
+  - `poe all` で最終品質ゲート通過
+  - Purpose: 全 endpoint の統合動作を検証し、リグレッションなしを最終確認
+  - _Leverage: test-design.md Full Flow Test コード_
+  - _Requirements: R2-AC1〜AC11, R1-AC3_
+  - **完了基準**:
+    - full flow テストが Design → Review → Knowledge → Rules の全フローを通過
+    - 332 テスト全通過（260 既存 + 72 新規）
+    - `poe all` が exit 0
+  - **確認手順**:
+    ```bash
+    uv run pytest tests/test_web_integration.py::test_full_flow_create_to_knowledge -v
+    ```
+    1 passed を確認
+    ```bash
+    uv run pytest --co -q | tail -1
+    ```
+    332 tests collected を確認
+    ```bash
+    poe all
+    ```
+    exit 0 を確認
+  - _Prompt: Role: QA Engineer with integration testing expertise | Task: Write test_full_flow_create_to_knowledge: POST designs → PUT activate → POST review → POST comments → POST knowledge (preview) → POST knowledge (save) → GET rules/context. Run poe all for final gate | Restrictions: Real YAML (no mocks). Verify round-trip data integrity. Do not modify existing tests | Success: Full flow passes, 332 total tests pass, poe all succeeds_

--- a/.spec-workflow/specs/SPEC-4a/test-design.md
+++ b/.spec-workflow/specs/SPEC-4a/test-design.md
@@ -1,0 +1,496 @@
+# SPEC-4a: webui-backend — Test Design
+
+> **Spec ID**: SPEC-4a
+> **Status**: draft
+> **Created**: 2026-02-27
+> **Depends On**: SPEC-1, SPEC-2, SPEC-3
+
+---
+
+## Test Architecture
+
+### Test Pyramid
+
+```
+          ┌─────────────┐
+          │  E2E (HTTP)   │  ← test_web_integration.py (full flow + daemon)
+          ├─────────────┤
+        ┌─┤  Integration  ├─┐  ← test_web_cli.py (CLI + browser + stderr)
+        │ ├─────────────┤ │
+  ┌─────┴─┴─────────────┴─┴─────┐
+  │     Unit Tests (~60 tests)    │  ← test_registry.py, test_web.py
+  └──────────────────────────────┘
+```
+
+### Test File Layout
+
+| File | Target Module | Test Count | Pattern |
+|------|--------------|-----------|---------|
+| `tests/test_registry.py` | `_registry.py` | 9 | Function-based |
+| `tests/test_web.py` | `web.py` (REST endpoints) | 51 | Function-based (per endpoint group) |
+| `tests/test_web_integration.py` | `web.py` (full flow + server lifecycle) | 8 | Function-based |
+| `tests/test_web_cli.py` | `cli.py` (headless, browser, stderr) | 4 | Function-based |
+| `tests/test_server.py` (modified) | `server.py` (_registry migration) | 0 new (fixture update) | Existing pattern |
+| `tests/conftest.py` (modified) | Shared fixtures | 0 new (wiring update) | Existing pattern |
+
+**Total**: 72 new test cases
+
+## Shared Fixtures
+
+### Existing (`conftest.py` — modification required)
+
+```python
+# 変更: _registry 経由の配線に切り替え
+# server_module._service = ... → registry.design_service = ...
+import insight_blueprint._registry as registry
+
+@pytest.fixture
+def tmp_project(tmp_path: Path) -> Path:
+    """Return a temporary project directory with .insight/ initialized."""
+    from insight_blueprint.storage.project import init_project
+    init_project(tmp_path)
+    return tmp_path
+```
+
+### New Fixtures (`tests/test_web.py` 内 or `conftest.py`)
+
+```python
+import insight_blueprint._registry as registry
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Reset all _registry service references after each test.
+
+    autouse=True: web_client を使わないテスト（test_error_500_uninitialized 等）
+    でもグローバル状態をリセットし、テスト順序依存を防ぐ。
+    """
+    yield
+    registry.design_service = None
+    registry.catalog_service = None
+    registry.review_service = None
+    registry.rules_service = None
+
+@pytest.fixture
+def web_client(tmp_project: Path) -> Generator[TestClient, None, None]:
+    """TestClient with all services wired via _registry.
+
+    yield + context manager で TestClient のリソースリークを防止。
+    """
+    from insight_blueprint.core.catalog import CatalogService
+    from insight_blueprint.core.designs import DesignService
+    from insight_blueprint.core.reviews import ReviewService
+    from insight_blueprint.core.rules import RulesService
+    from insight_blueprint.web import app
+
+    ds = DesignService(tmp_project)
+    cs = CatalogService(tmp_project)
+    registry.design_service = ds
+    registry.catalog_service = cs
+    registry.review_service = ReviewService(tmp_project, ds)
+    registry.rules_service = RulesService(tmp_project, cs)
+    with TestClient(app) as client:
+        yield client
+```
+
+### Daemon Thread テスト用 Fixture
+
+```python
+@pytest.fixture
+def _server_lifecycle(tmp_project: Path) -> Generator[int, None, None]:
+    """Start server in daemon thread, yield port, ensure shutdown.
+
+    ThreadedUvicorn.should_exit = True で確実に停止し、
+    CI でのリソースリーク・ポート競合を防止。
+    """
+    from insight_blueprint.web import start_server, _server_instance  # internal ref
+
+    # Wire services (same as web_client)
+    # ...
+    port = start_server(host="127.0.0.1", port=0)
+    yield port
+    # Cleanup: signal server to exit
+    if _server_instance is not None:
+        _server_instance.should_exit = True
+```
+
+### Design Note: Fixture Scope & Isolation
+
+- 全 fixture は default `function` scope。各テストが独立した `tmp_path` を持つ
+- `_reset_registry` は **autouse=True** でテスト間のグローバル状態を確実にリセット
+- `web_client` は `with TestClient(app) as client:` で HTTP 接続プールを解放
+- daemon thread テストは `should_exit = True` で確実に停止
+- `test_server.py` の既存 `_reset_service` fixture は `_registry` 向けに書き換え
+  （両 reset fixture の共存を避け、`_registry` に一本化する）
+
+## Test Data
+
+### Sample Request Bodies
+
+```python
+# POST /api/designs
+VALID_DESIGN_REQUEST = {
+    "title": "Population Analysis",
+    "hypothesis_statement": "Population correlates with GDP",
+    "hypothesis_background": "Testing economic indicators",
+    "theme_id": "FP",
+}
+
+MINIMAL_DESIGN_REQUEST = {
+    "title": "Minimal",
+    "hypothesis_statement": "Minimal hypothesis",
+    "hypothesis_background": "Minimal background",
+}
+
+# POST /api/catalog/sources
+VALID_SOURCE_REQUEST = {
+    "source_id": "estat-pop",
+    "name": "Population Statistics",
+    "type": "csv",
+    "description": "Annual population census data",
+    "connection": {"path": "/data/population.csv"},
+    "columns": [
+        {"name": "year", "type": "integer", "description": "Census year"},
+        {"name": "population", "type": "integer", "description": "Total population"},
+    ],
+    "tags": ["demographic", "census"],
+}
+
+INVALID_SOURCE_REQUEST = {
+    "source_id": "test",
+    # missing required fields: name, type, description, connection
+}
+
+# POST /api/designs/{id}/comments
+VALID_COMMENT_REQUEST = {
+    "comment": "caution: 2015年以降の人口統計は調査方法が変更されている。",
+    "status": "supported",
+    "reviewer": "analyst",
+}
+
+INVALID_STATUS_COMMENT = {
+    "comment": "test",
+    "status": "pending_review",  # invalid post-review status
+}
+
+# POST /api/designs/{id}/knowledge (save mode)
+VALID_KNOWLEDGE_REQUEST = {
+    "entries": [
+        {
+            "key": "FP-H01-0",
+            "title": "Census methodology change",
+            "content": "Census methodology changed in 2015",
+            "category": "caution",
+            "source": "Review comment",
+            "affects_columns": ["population_stats"],
+        }
+    ],
+}
+
+INVALID_KNOWLEDGE_REQUEST = {
+    "entries": [{"invalid": "structure"}],  # missing required fields
+}
+```
+
+### Expected Response Shapes
+
+```python
+# Error responses — FR-8 contract: {"error": str}
+# All 400/404/500 must use this shape (not FastAPI default {"detail": ...})
+
+# GET /api/health
+HEALTH_RESPONSE_KEYS = {"status", "version"}
+
+# GET /api/designs
+DESIGNS_LIST_KEYS = {"designs", "count"}
+
+# POST /api/designs (201)
+DESIGN_CREATED_KEYS = {"design", "message"}
+```
+
+## Mock Strategy
+
+### What to Mock
+
+| Dependency | Where | Mock Approach |
+|-----------|-------|--------------|
+| Nothing | `test_registry.py` | Pure module state tests |
+| Nothing | `test_web.py` | Real services via `web_client` fixture + `tmp_project` |
+| Service getter (force exception) | `test_web.py` (500 test) | `unittest.mock.patch` on getter to raise |
+| `webbrowser.open` | `test_web_cli.py` | `unittest.mock.patch` |
+| `threading.Timer` | `test_web_cli.py` | `unittest.mock.patch` |
+| Nothing | `test_web_integration.py` | Real services + real daemon thread |
+
+### Design Note: Real Services for Endpoint Tests
+
+SPEC-1/2/3 パターンに従い、`test_web.py` のエンドポイントテストは
+real services + real YAML files を使う。TestClient は uvicorn を起動せず
+FastAPI app を直接テストするため、十分高速（< 100ms/test）。
+
+サービスレベルの mock は行わない（500 テスト以外）。理由:
+1. エンドポイントの薄いレイヤー（パラメータ変換 + ステータスコード変換）をテストする
+2. サービス自体のロジックは SPEC-1/2/3 のテストで検証済み
+3. Real YAML により、パラメータの型変換ミスを早期発見
+
+`test_error_500_unexpected` のみ、真の unexpected exception パスをテストするため
+getter を mock して `RuntimeError` を送出させる。
+
+## Test Specifications by File
+
+### `test_registry.py` — 9 Tests
+
+Tests `_registry.py` module-level state and getters.
+
+| # | Test Name | AC | Input | Expected |
+|---|-----------|-----|-------|----------|
+| 1 | `test_get_design_service_uninitialized_raises` | R1-AC1 | Call before wiring | `RuntimeError` |
+| 2 | `test_get_catalog_service_uninitialized_raises` | R1-AC1 | Call before wiring | `RuntimeError` |
+| 3 | `test_get_review_service_uninitialized_raises` | R1-AC1 | Call before wiring | `RuntimeError` |
+| 4 | `test_get_rules_service_uninitialized_raises` | R1-AC1 | Call before wiring | `RuntimeError` |
+| 5 | `test_get_design_service_after_wiring` | R1-AC2 | Set `design_service`, call getter | Returns same instance |
+| 6 | `test_get_catalog_service_after_wiring` | R1-AC2 | Set `catalog_service`, call getter | Returns same instance |
+| 7 | `test_get_review_service_after_wiring` | R1-AC2 | Set `review_service`, call getter | Returns same instance |
+| 8 | `test_get_rules_service_after_wiring` | R1-AC2 | Set `rules_service`, call getter | Returns same instance |
+| 9 | `test_registry_contains_no_business_logic` | R1-AC4 | Inspect module attributes | No functions other than `get_*`, no class definitions |
+
+### `test_web.py` — 51 Tests
+
+Tests REST endpoints via `TestClient`. Function-based（既存パターンに統一）。
+`_reset_registry` autouse + `web_client` yield fixture 使用。
+
+#### Design Endpoints (10 tests)
+
+| # | Test Name | AC | Action | Expected |
+|---|-----------|-----|--------|----------|
+| 1 | `test_list_designs_empty` | R2-AC1 | `GET /api/designs` | 200, `{designs: [], count: 0}` |
+| 2 | `test_list_designs_returns_all` | R2-AC1 | Create 2 designs → `GET /api/designs` | 200, count=2 |
+| 3 | `test_list_designs_filter_by_status` | R2-AC1 | Create + activate → `GET /api/designs?status=active` | 200, filtered result |
+| 4 | `test_create_design_success` | R2-AC2 | `POST /api/designs` + `VALID_DESIGN_REQUEST` | 201, `{design, message}` |
+| 5 | `test_create_design_missing_field` | — | `POST /api/designs` + `{title: "x"}` | 422 |
+| 6 | `test_get_design_found` | R2-AC1 | Create → `GET /api/designs/{id}` | 200, design dict |
+| 7 | `test_get_design_not_found` | R2-AC3 | `GET /api/designs/nonexistent` | 404, `{"error": ...}` |
+| 8 | `test_get_design_invalid_id` | — | `GET /api/designs/invalid%20id` | 422 |
+| 9 | `test_update_design_success` | — | Create → `PUT /api/designs/{id}` + `{title: "new"}` | 200 |
+| 10 | `test_update_design_not_found` | — | `PUT /api/designs/nonexistent` | 404 |
+
+#### Catalog Endpoints (17 tests)
+
+| # | Test Name | AC | Action | Expected |
+|---|-----------|-----|--------|----------|
+| 11 | `test_list_sources_empty` | R2-AC4 | `GET /api/catalog/sources` | 200, `{sources: [], count: 0}` |
+| 12 | `test_list_sources_returns_all` | R2-AC4 | Add source → `GET /api/catalog/sources` | 200, count=1 |
+| 13 | `test_add_source_success` | R2-AC4 | `POST /api/catalog/sources` + `VALID_SOURCE_REQUEST` | 201 |
+| 14 | `test_add_source_duplicate` | — | Add same source twice | 400, `{"error": ...}` |
+| 15 | `test_add_source_missing_field` | — | `POST /api/catalog/sources` + `INVALID_SOURCE_REQUEST` | 422 |
+| 16 | `test_get_source_found` | — | Add → `GET /api/catalog/sources/{id}` | 200 |
+| 17 | `test_get_source_not_found` | — | `GET /api/catalog/sources/nonexistent` | 404 |
+| 18 | `test_get_source_invalid_id` | — | `GET /api/catalog/sources/inv@lid` | 422 |
+| 19 | `test_update_source_success` | — | Add → `PUT /api/catalog/sources/{id}` | 200 |
+| 20 | `test_update_source_not_found` | — | `PUT /api/catalog/sources/nonexistent` | 404 |
+| 21 | `test_get_schema_found` | R2-AC4 | Add source with columns → `GET .../schema` | 200, `{source_id, columns}` |
+| 22 | `test_get_schema_not_found` | — | `GET /api/catalog/sources/nonexistent/schema` | 404 |
+| 23 | `test_search_with_results` | R2-AC4 | Add source → `GET /api/catalog/search?q=population` | 200, results |
+| 24 | `test_search_no_results` | — | `GET /api/catalog/search?q=nonexistent` | 200, `{results: [], count: 0}` |
+| 25 | `test_search_with_source_id_filter` | — | Add 2 sources → search with `&source_id=X` | Only X results |
+| 26 | `test_search_missing_query` | — | `GET /api/catalog/search` (no q) | 422 |
+| 27 | `test_get_knowledge_list` | R2-AC4 | Add source → `GET /api/catalog/knowledge` | 200 |
+
+#### Review Endpoints (12 tests)
+
+| # | Test Name | AC | Action | Expected |
+|---|-----------|-----|--------|----------|
+| 28 | `test_submit_review_success` | R2-AC5 | Create active design → `POST .../review` | 200, `{design_id, status, message}` |
+| 29 | `test_submit_review_non_active` | R2-AC5 | Draft design → `POST .../review` | 400 |
+| 30 | `test_submit_review_not_found` | — | `POST /api/designs/nonexistent/review` | 404 |
+| 31 | `test_list_comments_with_data` | R2-AC5 | Submit + comment → `GET .../comments` | 200, count=1 |
+| 32 | `test_list_comments_empty` | — | Active design → `GET .../comments` | 200, `{comments: [], count: 0}` |
+| 33 | `test_add_comment_success` | R2-AC6 | Submit → `POST .../comments` + `VALID_COMMENT_REQUEST` | 200 |
+| 34 | `test_add_comment_invalid_status` | R2-AC6 | Submit → `POST .../comments` + `INVALID_STATUS_COMMENT` | 400 |
+| 35 | `test_add_comment_not_found` | — | `POST /api/designs/nonexistent/comments` + body | 404 |
+| 36 | `test_knowledge_preview` | R2-AC10 | Submit → comment → `POST .../knowledge` (no body) | 200, preview entries |
+| 37 | `test_knowledge_save` | R2-AC11 | Submit → comment → `POST .../knowledge` + entries | 200, saved entries |
+| 38 | `test_knowledge_not_found` | — | `POST /api/designs/nonexistent/knowledge` | 404 |
+| 39 | `test_knowledge_invalid_entries` | — | `POST .../knowledge` + `INVALID_KNOWLEDGE_REQUEST` | 400 |
+
+#### Rules Endpoints (4 tests)
+
+| # | Test Name | AC | Action | Expected |
+|---|-----------|-----|--------|----------|
+| 40 | `test_get_context` | R2-AC7 | `GET /api/rules/context` | 200, `{sources, knowledge_entries, rules, ...}` |
+| 41 | `test_cautions_with_matches` | R2-AC8 | Add knowledge → `GET /api/rules/cautions?table_names=X` | 200, cautions |
+| 42 | `test_cautions_no_matches` | — | `GET /api/rules/cautions?table_names=unknown` | 200, `{cautions: [], count: 0}` |
+| 43 | `test_cautions_missing_param` | — | `GET /api/rules/cautions` (no table_names) | 422 |
+
+#### Health & Error Format (8 tests)
+
+| # | Test Name | AC | Action | Expected |
+|---|-----------|-----|--------|----------|
+| 44 | `test_health_check` | R3-AC3 | `GET /api/health` (with services) | 200, `{status: "ok", version: str}` |
+| 45 | `test_health_check_no_services` | FR-12 | `GET /api/health` (no _registry wiring) | 200 (サービス初期化不要) |
+| 46 | `test_error_400_format` | R2-AC9 | Trigger ValueError path | `{"error": str}` (not `{"detail": ...}`) |
+| 47 | `test_error_404_format` | R2-AC9 | Trigger not-found path | `{"error": str}` |
+| 48 | `test_error_500_uninitialized` | R2-AC9 | No services wired → design endpoint | 500, `{"error": ...}` |
+| 49 | `test_error_500_unexpected` | R2-AC9 | Mock getter to raise unexpected Exception | 500, `{"error": "Internal server error"}`, no stack trace in body |
+| 50 | `test_cors_localhost_allowed` | FR-9 | `OPTIONS /api/health` with `Origin: http://localhost:3000` | CORS headers present |
+| 51 | `test_cors_external_rejected` | FR-9 | `OPTIONS /api/health` with `Origin: http://evil.com` | No CORS headers |
+
+### `test_web_integration.py` — 8 Tests
+
+Full-flow integration tests with real services and daemon thread.
+
+#### Full Flow Test
+
+```python
+def test_full_flow_create_to_knowledge(web_client: TestClient) -> None:
+    """Integration: create → activate → review → comment → knowledge."""
+    # 1. POST /api/designs
+    resp = web_client.post("/api/designs", json=VALID_DESIGN_REQUEST)
+    assert resp.status_code == 201
+    design_id = resp.json()["design"]["id"]
+
+    # 2. PUT /api/designs/{id} (activate)
+    resp = web_client.put(f"/api/designs/{design_id}", json={"status": "active"})
+    assert resp.status_code == 200
+
+    # 3. POST /api/designs/{id}/review
+    resp = web_client.post(f"/api/designs/{design_id}/review")
+    assert resp.status_code == 200
+
+    # 4. POST /api/designs/{id}/comments
+    resp = web_client.post(
+        f"/api/designs/{design_id}/comments", json=VALID_COMMENT_REQUEST
+    )
+    assert resp.status_code == 200
+
+    # 5. POST /api/designs/{id}/knowledge (preview)
+    resp = web_client.post(f"/api/designs/{design_id}/knowledge")
+    assert resp.status_code == 200
+    assert resp.json()["count"] >= 1
+
+    # 6. POST /api/designs/{id}/knowledge (save)
+    entries = resp.json()["entries"]
+    resp = web_client.post(
+        f"/api/designs/{design_id}/knowledge", json={"entries": entries}
+    )
+    assert resp.status_code == 200
+
+    # 7. Verify in rules context
+    resp = web_client.get("/api/rules/context")
+    assert resp.json()["total_knowledge"] >= 1
+```
+
+#### Server Lifecycle Tests
+
+全 daemon thread テストは `_server_lifecycle` fixture を使い、
+`should_exit = True` で確実にサーバーを停止する。ポートは `port=0`
+（OS 割り当て）をデフォルトにし、CI でのポート競合を回避する。
+
+| # | Test Name | AC | Description |
+|---|-----------|-----|-------------|
+| 1 | `test_full_flow_create_to_knowledge` | R2-AC1~11 | Design 作成 → review → comment → knowledge の全フロー |
+| 2 | `test_start_server_returns_port` | R3-AC1 | `start_server(port=0)` が有効な port > 0 を返す |
+| 3 | `test_start_server_specific_port` | R3-AC1 | `start_server(port=N)` が port N で起動（N = OS割り当て済み空きポート） |
+| 4 | `test_start_server_health_check` | R3-AC3 | `start_server()` 後に `GET /api/health` が応答 |
+| 5 | `test_start_server_port_fallback` | R3-AC2 | 使用中ポート指定時に別ポートで起動 |
+| 6 | `test_start_server_shutdown` | R3-AC6 | `should_exit = True` 後にスレッドが終了 |
+| 7 | `test_static_files_served` | R3-AC7 | `static/index.html` 配置時に `GET /` で配信 |
+| 8 | `test_static_missing_returns_404` | R3-AC8 | `static/` 未配置時に `GET /` が 404（クラッシュしない） |
+
+### `test_web_cli.py` — 4 Tests
+
+CLI 統合テスト。`webbrowser.open` と `threading.Timer` を mock。
+
+| # | Test Name | AC | Setup | Expected |
+|---|-----------|-----|-------|----------|
+| 1 | `test_headless_no_browser` | R3-AC5 | `--headless` + mock `webbrowser.open` | `webbrowser.open` not called |
+| 2 | `test_default_opens_browser` | R3-AC4 | No `--headless` + mock `webbrowser.open` | `threading.Timer` created with `webbrowser.open` |
+| 3 | `test_stderr_url_output` | R3-AC3 | Capture stderr | `"WebUI: http://127.0.0.1:{port}"` in stderr |
+| 4 | `test_localhost_binding` | R3-AC1 | Inspect uvicorn config | `host == "127.0.0.1"` (not `0.0.0.0`) |
+
+## Edge Case Matrix
+
+### REST Endpoint Edge Cases
+
+| Case | Endpoint | Input | Expected | Test |
+|------|----------|-------|----------|------|
+| Invalid ID format | `GET /api/designs/{id}` | `id="invalid id"` (space) | 422 | `test_get_design_invalid_id` |
+| Invalid ID special chars | `GET /api/catalog/sources/{id}` | `id="inv@lid"` | 422 | `test_get_source_invalid_id` |
+| Empty body | `POST /api/designs` | `{}` | 422 (missing required) | `test_create_design_missing_field` |
+| Partial body | `POST /api/catalog/sources` | Missing name/type/desc | 422 | `test_add_source_missing_field` |
+| Duplicate source | `POST /api/catalog/sources` | Same source_id twice | 400 | `test_add_source_duplicate` |
+| Search no query | `GET /api/catalog/search` | No `q` param | 422 | `test_search_missing_query` |
+| Cautions no param | `GET /api/rules/cautions` | No `table_names` | 422 | `test_cautions_missing_param` |
+| Invalid review status | `POST .../comments` | `status="pending_review"` | 400 | `test_add_comment_invalid_status` |
+| Comment not found | `POST .../comments` | nonexistent design | 404 | `test_add_comment_not_found` |
+| Knowledge not found | `POST .../knowledge` | nonexistent design | 404 | `test_knowledge_not_found` |
+| Knowledge invalid entries | `POST .../knowledge` | malformed entries | 400 | `test_knowledge_invalid_entries` |
+| Preview vs save | `POST .../knowledge` | No body vs with body | Preview vs persist | `test_knowledge_preview`, `test_knowledge_save` |
+| Services uninitialized | Any endpoint | No `_registry` wiring | 500, `{"error": ...}` | `test_error_500_uninitialized` |
+| Unexpected exception | Any endpoint | Getter raises Exception | 500, no stack trace | `test_error_500_unexpected` |
+
+### Server Startup Edge Cases
+
+| Case | Input | Expected | Test |
+|------|-------|----------|------|
+| Port 0 (OS assign) | `start_server(port=0)` | Returns assigned port > 0 | `test_start_server_returns_port` |
+| Specific port | `start_server(port=N)` | Uses N when free | `test_start_server_specific_port` |
+| Port conflict | `start_server(port=occupied)` | Falls back to OS port | `test_start_server_port_fallback` |
+| Shutdown | `server.should_exit = True` | Thread terminates | `test_start_server_shutdown` |
+| Static missing | No `static/` dir | `GET /` → 404 (no crash) | `test_static_missing_returns_404` |
+| Static present | `static/index.html` exists | `GET /` → 200 | `test_static_files_served` |
+
+### Error Response Format
+
+| Status | Body Format | Verified By |
+|--------|------------|-------------|
+| 400 | `{"error": "..."}` | `test_error_400_format` |
+| 404 | `{"error": "..."}` | `test_error_404_format` |
+| 422 | FastAPI default validation | `test_create_design_missing_field` |
+| 500 (uninitialized) | `{"error": "..."}` | `test_error_500_uninitialized` |
+| 500 (unexpected) | `{"error": "Internal server error"}` (no stack trace) | `test_error_500_unexpected` |
+
+## Build Pipeline Testing
+
+ビルドパイプライン（FR-13/14/15/16）の自動テストは Node.js 依存のため、
+pytest テストスイートには含めない。以下の方針で検証する:
+
+| AC | Verification | Method |
+|----|-------------|--------|
+| R4-AC1 (`poe build-frontend` → static/) | `static/index.html` が存在 | CI ジョブ or 手動 |
+| R4-AC2 (wheel に static 含む) | `uv build` → wheel 内ファイル確認 | CI ジョブ or 手動 |
+| R4-AC4 (frontend/ が有効な Vite project) | `cd frontend && npm install && npm run build` | CI ジョブ |
+| R4-AC5 (`poe build` 順序) | `poe build` 実行でフルビルド成功 | CI ジョブ |
+
+**CI ジョブ設計**: Node.js + Python の matrix CI で `poe build` を実行し、
+wheel 内の `insight_blueprint/static/index.html` の存在を `zipinfo` で確認する。
+pytest とは別ジョブとして実行。
+
+## Regression Strategy
+
+SPEC-4a は共有モジュール（`cli.py`, `server.py`, `conftest.py`）を変更する。
+リグレッション防止:
+
+1. **R1-AC3: 既存 183 テスト全通過** — `_registry` への移行後も全テストが通ること
+   - `test_server.py` の `_reset_service` fixture を `_registry` 向けに更新
+     （legacy `server_module._service` reset を廃止し、`_registry` reset に一本化）
+   - `conftest.py` の service fixture wiring を `_registry` 経由に変更
+   - import パス変更以外のロジック変更なし
+   - **検証**: `uv run pytest` で全既存テスト通過を CI ゲートとする
+
+2. **server.py の既存 MCP ツールテスト** — getter が `_registry` 経由に
+   変わるだけで、テストの assertion は全て同一
+
+3. **conftest.py の fixture 互換性** — `design_service`, `review_service` 等の
+   fixture は同じ型を返す。呼び出し側の変更不要
+
+4. **新テストの独立性** — `test_web.py` は `web_client` yield fixture で独立。
+   `_reset_registry` autouse fixture で `_registry` グローバル状態をリセット
+
+## Security Testing
+
+| # | Test | Verification |
+|---|------|-------------|
+| 1 | `test_localhost_binding` | uvicorn config の `host` が `"127.0.0.1"` |
+| 2 | `test_error_500_unexpected` | stack trace が response body に漏れない |
+| 3 | `test_error_400_format` | ValueError メッセージが `{"error": ...}` 形式で返る |
+| 4 | `test_cors_localhost_allowed` | localhost origin の CORS リクエストにヘッダーが付く |
+| 5 | `test_cors_external_rejected` | 外部 origin の CORS リクエストが拒否される |

--- a/.spec-workflow/specs/SPEC-4b/design.md
+++ b/.spec-workflow/specs/SPEC-4b/design.md
@@ -1,0 +1,585 @@
+# SPEC-4b: webui-frontend — Design
+
+> **Spec ID**: SPEC-4b
+> **Created**: 2026-02-28
+
+---
+
+## Overview
+
+SPEC-4a で構築した FastAPI REST API (18 endpoints) を消費する React フロントエンドを
+`frontend/` に実装する。既存の Vite + React + Tailwind CSS v4 scaffold に shadcn/ui を
+追加し、4タブダッシュボード（Designs / Catalog / Rules / History）を構築する。
+ビルド成果物は `src/insight_blueprint/static/` に出力され、既存の wheel 同梱パイプラインで配布される。
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+
+- Frontend: React 19 + Vite 6 + Tailwind CSS + shadcn/ui（tech.md §WebUI 準拠）
+- Static files: `src/insight_blueprint/static/` — hatch `artifacts` config で wheel に同梱
+- ビルド: `poe build-frontend` → `cd frontend && npm install && npm run build`
+- TypeScript strict mode（tech.md §YAGNI に基づき最小限の抽象化）
+
+### Project Structure (structure.md)
+
+- `frontend/` は structure.md §Repository Layout に定義済み
+- `frontend/src/` 内のディレクトリ構成は SPEC-4b で新規定義
+- `static/` はビルド成果物のみ（.gitignore 対象）
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+
+- **SPEC-4a frontend scaffold** (`frontend/`): Vite 6 + React 19 + Tailwind CSS v4 の
+  基盤設定が完了済み。`vite.config.ts`, `tsconfig.json`, `index.html`, `main.tsx` を拡張する
+- **SPEC-4a `web.py`**: REST API 契約（18 endpoints）がそのまま TypeScript 型定義のソース
+- **SPEC-4a Pydantic リクエストモデル**: `CreateDesignRequest`, `AddCommentRequest`,
+  `AddSourceRequest`, `SaveKnowledgeRequest` の構造を TypeScript 型に変換
+- **SPEC-4a ビルドパイプライン**: `poe build-frontend`, `poe build` が既存。変更不要
+
+### Integration Points
+
+- **FastAPI REST API (SPEC-4a)**: `api/client.ts` から `fetch()` で呼び出し。
+  開発時は Vite proxy、本番は同一オリジン配信
+- **`static/` ディレクトリ**: `npm run build` の出力先。`web.py` の `StaticFiles` mount で配信
+- **CORS 設定**: `web.py` で `localhost:5173`（Vite dev server）が既に許可済み
+
+## Architecture
+
+### 全体構成
+
+```
+frontend/src/
+├── main.tsx                    # Entry point (React root)
+├── App.tsx                     # Shell: Header + TabBar + Page routing
+├── api/
+│   └── client.ts               # fetch wrapper + all endpoint functions
+├── components/
+│   ├── DataTable.tsx           # Generic table (shadcn/ui Table)
+│   ├── StatusBadge.tsx         # DesignStatus color badge (shadcn/ui Badge)
+│   ├── EmptyState.tsx          # Zero-data placeholder
+│   ├── ErrorBanner.tsx         # API error display (shadcn/ui Alert)
+│   └── JsonTree.tsx            # Collapsible JSON viewer (for dict fields)
+├── pages/
+│   ├── DesignsPage.tsx         # Master list + detail panel
+│   ├── DesignDetail.tsx        # Detail with sub-tabs (Overview/Review/Knowledge)
+│   ├── CatalogPage.tsx         # Source list + schema + search + knowledge
+│   ├── RulesPage.tsx           # Project context + cautions search
+│   └── HistoryPage.tsx         # Recent activity timeline
+└── types/
+    └── api.ts                  # TypeScript type definitions for API responses
+```
+
+### Data Flow
+
+```
+User Action → Page Component → api/client.ts → fetch() → FastAPI REST API
+                                                              ↓
+User sees ← Page Component ← useState update ← JSON response ←┘
+```
+
+### Modular Design Principles
+
+- **Single File Responsibility**: 1ファイル = 1コンポーネント or 1モジュール。
+  ページコンポーネントは自身の API 呼び出しと状態管理を完結させる
+- **Component Isolation**: ページ間で状態を共有しない。各ページは独立して `useState` +
+  `useEffect` で API データを管理する。グローバル状態管理ライブラリは不要
+- **Service Layer Separation**: API 呼び出しは `api/client.ts` に集約。
+  ページコンポーネントから直接 `fetch()` を呼ばない
+- **Utility Modularity**: 共通コンポーネント（`DataTable`, `StatusBadge` 等）は
+  2箇所以上で使用されるもののみ切り出す。1箇所でしか使わないものはページ内で完結
+- **Race Condition Prevention**: 全ての `useEffect` 内 fetch に `AbortController` を使用。
+  コンポーネントのアンマウントや依存値の変更時にリクエストをキャンセルし、
+  stale レスポンスによる誤表示を防ぐ:
+  ```tsx
+  useEffect(() => {
+    const ctrl = new AbortController();
+    listDesigns(statusFilter, ctrl.signal)
+      .then(setDesigns)
+      .catch(err => { if (err.name !== "AbortError") setError(err.message); });
+    return () => ctrl.abort();
+  }, [statusFilter]);
+  ```
+
+## Components and Interfaces
+
+### Component 1: `App.tsx`
+
+- **Purpose**: Application shell。ヘッダー + タブバー + ページルーティングを提供
+- **Interfaces**:
+  ```tsx
+  type Tab = "designs" | "catalog" | "rules" | "history";
+
+  function App(): JSX.Element
+  // - useState<Tab> でアクティブタブを管理
+  // - URLSearchParams で ?tab= パラメータと同期
+  // - 不正な ?tab= 値は "designs" にフォールバック
+  // - タブ切り替え時に history.replaceState で URL 更新
+  // - popstate イベントをリッスンしてブラウザ戻る/進むに対応
+  // - shadcn/ui Tabs で UI 描画
+  ```
+- **Dependencies**: shadcn/ui `Tabs`, 全ページコンポーネント
+- **Reuses**: なし（新規）
+
+### Component 2: `api/client.ts`
+
+- **Purpose**: 全 REST API 呼び出しの集約。薄い fetch wrapper
+- **Interfaces**:
+  ```typescript
+  // --- Core request helper ---
+  // All endpoint functions delegate to this shared helper.
+  // Handles: JSON parse, {error} extraction, 422 normalization, non-JSON fallback.
+  async function request<T>(path: string, init?: RequestInit): Promise<T>
+  // - Calls fetch(path, init)
+  // - If !res.ok: tries JSON parse → extracts {error} or {detail} (FastAPI 422)
+  //   → falls back to res.statusText for non-JSON responses → throws ApiError
+  // - AbortError (from AbortController) is re-thrown as-is (not wrapped in ApiError)
+  // - On network error (TypeError from fetch): throws ApiError with "サーバーに接続できません"
+
+  // Error class
+  class ApiError extends Error {
+    status: number;   // HTTP status code (0 for network errors)
+    detail: string;   // Server error message or fallback
+  }
+
+  // Design endpoints
+  // All endpoint functions accept an optional AbortSignal for cancellation.
+  // Design endpoints
+  function listDesigns(status?: string, signal?: AbortSignal): Promise<{ designs: Design[]; count: number }>
+  function createDesign(body: CreateDesignRequest): Promise<{ design: Design; message: string }>
+  function getDesign(id: string, signal?: AbortSignal): Promise<Design>
+
+  // Review endpoints
+  function submitReview(designId: string): Promise<{ design_id: string; status: string; message: string }>
+  function listComments(designId: string): Promise<{ design_id: string; comments: ReviewComment[]; count: number }>
+  function addComment(designId: string, body: AddCommentRequest): Promise<{ comment_id: string; status_after: string; message: string }>
+  function extractKnowledge(designId: string): Promise<{ entries: KnowledgeEntry[]; count: number; message: string }>
+  function saveKnowledge(designId: string, entries: KnowledgeEntry[]): Promise<{ saved_entries: KnowledgeEntry[]; count: number; message: string }>
+
+  // Catalog endpoints
+  function listSources(): Promise<{ sources: DataSource[]; count: number }>
+  function addSource(body: AddSourceRequest): Promise<{ source: DataSource; message: string }>
+  function getSource(id: string): Promise<DataSource>
+  function getSchema(sourceId: string): Promise<{ source_id: string; columns: ColumnSchema[] }>
+  function searchCatalog(query: string, sourceId?: string): Promise<{ query: string; results: SearchResult[]; count: number }>
+  function getKnowledgeList(): Promise<{ entries: KnowledgeEntry[]; count: number }>
+
+  // Rules endpoints
+  function getRulesContext(): Promise<RulesContext>
+  function getCautions(tableNames: string[]): Promise<{ table_names: string[]; cautions: Caution[]; count: number }>
+
+  // Health
+  function healthCheck(): Promise<{ status: string; version: string }>
+  ```
+- **Dependencies**: `types/api.ts`
+- **Reuses**: SPEC-4a `web.py` のエンドポイント定義を TypeScript に1:1マッピング
+
+### Component 3: `types/api.ts`
+
+- **Purpose**: API レスポンスの TypeScript 型定義。Python Pydantic モデルのミラー
+- **Interfaces**:
+  ```typescript
+  // Enums
+  type DesignStatus = "draft" | "active" | "pending_review" | "supported" | "rejected" | "inconclusive";
+  type SourceType = "csv" | "api" | "sql";
+  type KnowledgeCategory = "methodology" | "caution" | "definition" | "context";
+  type KnowledgeImportance = "high" | "medium" | "low";
+
+  // Models
+  interface Design {
+    id: string;
+    theme_id: string;
+    title: string;
+    hypothesis_statement: string;
+    hypothesis_background: string;
+    status: DesignStatus;
+    parent_id: string | null;
+    metrics: Record<string, unknown>;
+    explanatory: Record<string, unknown>[];
+    chart: Record<string, unknown>[];
+    source_ids: string[];
+    next_action: Record<string, unknown> | null;
+    created_at: string;  // ISO 8601
+    updated_at: string;
+  }
+
+  interface DataSource {
+    id: string;
+    name: string;
+    type: SourceType;
+    description: string;
+    connection: Record<string, unknown>;
+    schema_info: { columns: ColumnSchema[] };
+    tags: string[];
+    created_at: string;
+    updated_at: string;
+  }
+
+  interface ColumnSchema {
+    name: string;
+    type: string;
+    description: string;
+    nullable: boolean;
+    examples: string[] | null;
+    range: Record<string, unknown> | null;
+    unit: string | null;
+  }
+
+  interface ReviewComment {
+    id: string;
+    design_id: string;
+    comment: string;
+    reviewer: string;
+    status_after: DesignStatus;
+    created_at: string;
+    extracted_knowledge: string[];
+  }
+
+  interface KnowledgeEntry {
+    key: string;
+    title: string;
+    content: string;
+    category: KnowledgeCategory;
+    importance: KnowledgeImportance;
+    created_at: string;
+    source: string | null;
+    affects_columns: string[];
+  }
+
+  interface RulesContext {
+    sources: { id: string; name: string; type: string; description: string; tags: string[] }[];
+    knowledge_entries: KnowledgeEntry[];
+    rules: Record<string, unknown>[];
+    total_sources: number;
+    total_knowledge: number;
+    total_rules: number;
+  }
+
+  // Request types
+  interface CreateDesignRequest {
+    title: string;
+    hypothesis_statement: string;
+    hypothesis_background: string;
+    theme_id?: string;
+  }
+
+  interface AddCommentRequest {
+    comment: string;
+    status: string;
+    reviewer?: string;
+  }
+
+  interface AddSourceRequest {
+    source_id: string;
+    name: string;
+    type: SourceType;         // enum-constrained (not raw string)
+    description: string;
+    connection: Record<string, unknown>;
+    columns?: ColumnSchema[];
+    tags?: string[];
+  }
+
+  // API-derived types (not direct Pydantic mirrors)
+  interface SearchResult {
+    source_id: string;
+    column_name: string;
+    description: string;
+    [key: string]: unknown;   // FTS5 may return additional fields
+  }
+
+  interface Caution {
+    key: string;
+    title: string;
+    content: string;
+    category: KnowledgeCategory;
+    importance: KnowledgeImportance;
+    affects_columns: string[];
+    [key: string]: unknown;
+  }
+  ```
+- **Dependencies**: なし
+- **Reuses**: SPEC-4a Pydantic モデル（`models/design.py`, `models/catalog.py`,
+  `models/review.py`）を TypeScript に変換
+
+### Component 4: `DesignsPage.tsx`
+
+- **Purpose**: Designs タブのメインページ。マスター・ディテール構成
+- **Interfaces**:
+  ```tsx
+  function DesignsPage(): JSX.Element
+  // State:
+  //   designs: Design[]          — API から取得した全デザイン
+  //   selectedId: string | null  — 選択中のデザイン ID
+  //   statusFilter: string       — ステータスフィルタ値
+  //   loading: boolean
+  //   error: string | null
+  //
+  // Layout:
+  //   ┌─────────────────────────────────────────┐
+  //   │ [Filter: All ▼]          [+ New Design] │
+  //   │ ┌─────────────────────────────────────┐ │
+  //   │ │ DataTable (designs list)            │ │
+  //   │ └─────────────────────────────────────┘ │
+  //   │ ┌─────────────────────────────────────┐ │
+  //   │ │ DesignDetail (if selectedId)        │ │
+  //   │ └─────────────────────────────────────┘ │
+  //   └─────────────────────────────────────────┘
+  ```
+- **Dependencies**: `api/client.ts`, `DesignDetail`, `DataTable`, `StatusBadge`,
+  `EmptyState`, `ErrorBanner`, shadcn/ui `Select`, `Button`, `Dialog`
+- **Reuses**: なし（新規）
+
+### Component 5: `DesignDetail.tsx`
+
+- **Purpose**: 選択されたデザインの詳細表示。サブタブ (Overview / Review / Knowledge) を持つ
+- **Interfaces**:
+  ```tsx
+  interface DesignDetailProps {
+    designId: string;
+    onDesignUpdated: () => void;  // 親リストの再取得トリガー
+  }
+  function DesignDetail(props: DesignDetailProps): JSX.Element
+  // Sub-tabs rendered as separate child components:
+  //   OverviewPanel  — design fields display (JsonTree for dict fields)
+  //   ReviewPanel    — submit button, comments list, add comment form
+  //   KnowledgePanel — extract preview, save button
+  // Each panel is a separate function component in the same file,
+  // keeping DesignDetail.tsx as orchestrator (~150 lines) with panels (~60 lines each)
+  ```
+- **Dependencies**: `api/client.ts`, `JsonTree`, `StatusBadge`, `DataTable`,
+  shadcn/ui `Tabs`, `Card`, `Button`, `Textarea`, `Select`
+- **Reuses**: なし（新規）
+
+### Component 6: `CatalogPage.tsx`
+
+- **Purpose**: Catalog タブ。ソース一覧、スキーマ表示、検索、ドメイン知識表示
+- **Interfaces**:
+  ```tsx
+  function CatalogPage(): JSX.Element
+  // State:
+  //   sources: DataSource[]
+  //   selectedSourceId: string | null
+  //   schema: ColumnSchema[]
+  //   searchQuery: string
+  //   searchResults: SearchResult[]
+  //   knowledge: KnowledgeEntry[]
+  //   loading: boolean
+  //   error: string | null
+  //
+  // Layout:
+  //   ┌──────────────────────────────────────┐
+  //   │ [Search: ___________] [+ Add Source] │
+  //   │ ┌──────────────────────────────────┐ │
+  //   │ │ DataTable (sources list)         │ │
+  //   │ └──────────────────────────────────┘ │
+  //   │ ┌──────────────────────────────────┐ │
+  //   │ │ Schema table (if selected)       │ │
+  //   │ └──────────────────────────────────┘ │
+  //   │ ┌──────────────────────────────────┐ │
+  //   │ │ Domain Knowledge list            │ │
+  //   │ └──────────────────────────────────┘ │
+  //   └──────────────────────────────────────┘
+  //
+  // Internal sub-components (same file):
+  //   SourceListSection  — source table + add dialog
+  //   SchemaSection      — selected source schema table
+  //   SearchSection      — search bar + results
+  //   KnowledgeSection   — domain knowledge list
+  ```
+- **Dependencies**: `api/client.ts`, `DataTable`, `StatusBadge`, `EmptyState`,
+  `ErrorBanner`, shadcn/ui `Input`, `Button`, `Dialog`, `Select`
+- **Reuses**: なし（新規）
+
+### Component 7: `RulesPage.tsx`
+
+- **Purpose**: Rules タブ。プロジェクトコンテキスト表示 + Cautions 検索
+- **Interfaces**:
+  ```tsx
+  function RulesPage(): JSX.Element
+  // State:
+  //   context: RulesContext | null
+  //   tableNames: string
+  //   cautions: Caution[]
+  //   loading: boolean
+  //   error: string | null
+  //
+  // Layout:
+  //   ┌──────────────────────────────────────┐
+  //   │ Sources (N) | Knowledge (N) | Rules  │
+  //   │ ┌──────────────────────────────────┐ │
+  //   │ │ Context sections (collapsible)   │ │
+  //   │ └──────────────────────────────────┘ │
+  //   │ ┌──────────────────────────────────┐ │
+  //   │ │ [Table names: ___] [Search]      │ │
+  //   │ │ Cautions results                 │ │
+  //   │ └──────────────────────────────────┘ │
+  //   └──────────────────────────────────────┘
+  ```
+- **Dependencies**: `api/client.ts`, `DataTable`, `EmptyState`, `ErrorBanner`,
+  shadcn/ui `Input`, `Button`, `Card`
+- **Reuses**: なし（新規）
+
+### Component 8: `HistoryPage.tsx`
+
+- **Purpose**: History タブ。全デザインの最近の変更タイムライン + レビュー履歴展開
+- **Interfaces**:
+  ```tsx
+  function HistoryPage(): JSX.Element
+  // State:
+  //   designs: Design[]           — updated_at 降順ソート
+  //   expandedId: string | null   — 展開中のデザイン ID
+  //   comments: ReviewComment[]   — 展開中デザインのコメント
+  //   loading: boolean
+  //   error: string | null
+  ```
+- **Dependencies**: `api/client.ts`, `StatusBadge`, `EmptyState`, `ErrorBanner`,
+  shadcn/ui `Card`
+- **Reuses**: `listDesigns()` と `listComments()` を組み合わせて History を構成
+  （新規 API 不要）
+
+### Component 9: Shared UI Components
+
+- **`DataTable`**:
+  ```tsx
+  interface DataTableProps<T> {
+    data: T[];
+    columns: { key: keyof T; label: string; render?: (value: T[keyof T], row: T) => ReactNode }[];
+    onRowClick?: (row: T) => void;
+    selectedRow?: (row: T) => boolean;
+  }
+  ```
+  shadcn/ui `Table` をラップ。4ページで使用
+
+- **`StatusBadge`**:
+  ```tsx
+  interface StatusBadgeProps {
+    status: DesignStatus;
+  }
+  ```
+  カラーマッピング: draft=gray, active=blue, pending_review=yellow,
+  supported=green, rejected=red, inconclusive=orange
+
+- **`EmptyState`**:
+  ```tsx
+  interface EmptyStateProps {
+    message: string;
+    action?: { label: string; onClick: () => void };
+  }
+  ```
+
+- **`ErrorBanner`**:
+  ```tsx
+  interface ErrorBannerProps {
+    message: string;
+    onRetry?: () => void;
+  }
+  ```
+  shadcn/ui `Alert` ベース。再試行ボタン付き
+
+- **`JsonTree`**:
+  ```tsx
+  interface JsonTreeProps {
+    data: Record<string, unknown> | Record<string, unknown>[];
+    defaultExpanded?: boolean;
+  }
+  ```
+  `metrics`, `explanatory`, `chart`, `next_action`, `connection` の表示用。
+  折りたたみ可能な JSON ツリービュー。外部ライブラリ不要、再帰レンダリングで実装
+
+## Data Models
+
+SPEC-4b では新規データモデルを作成しない。`types/api.ts` で Python Pydantic モデルの
+TypeScript ミラーを定義する（Component 3 参照）。
+
+### API レスポンスと TypeScript 型の対応
+
+| Python Model | TypeScript Type | 使用場所 |
+|---|---|---|
+| `AnalysisDesign` | `Design` | DesignsPage, DesignDetail, HistoryPage |
+| `DataSource` | `DataSource` | CatalogPage |
+| `ColumnSchema` | `ColumnSchema` | CatalogPage (schema) |
+| `ReviewComment` | `ReviewComment` | DesignDetail (Review tab), HistoryPage |
+| `DomainKnowledgeEntry` | `KnowledgeEntry` | DesignDetail (Knowledge tab), CatalogPage, RulesPage |
+| `DesignStatus` (enum) | `DesignStatus` (union type) | StatusBadge |
+| `SourceType` (enum) | `SourceType` (union type) | CatalogPage |
+
+## Error Handling
+
+### Error Scenarios
+
+1. **API 通信エラー（ネットワーク）**
+   - Handling: `api/client.ts` の `fetch()` で `TypeError` をキャッチ → `ApiError` に変換
+   - User Impact: `ErrorBanner` に「サーバーに接続できません」+ 再試行ボタン
+
+2. **API エラーレスポンス（4xx/5xx）**
+   - Handling: `api/client.ts` で `!res.ok` を検出 → `{error}` body をパースして `ApiError` を throw
+   - User Impact: `ErrorBanner` にサーバーからのエラーメッセージを表示
+
+3. **デザイン未存在（404）**
+   - Handling: `getDesign()` が 404 → DesignDetail でエラー表示
+   - User Impact: 「指定されたデザインが見つかりません」
+
+4. **無効なフォーム入力**
+   - Handling: フロントエンドでバリデーション（必須項目チェック）、送信前にブロック
+   - User Impact: インラインエラーメッセージ（「タイトルは必須です」等）
+
+5. **JSON パースエラー（connection フィールド）**
+   - Handling: `JSON.parse()` の try-catch でバリデーション
+   - User Impact: 「有効な JSON を入力してください」
+
+6. **バックエンド未起動**
+   - Handling: 初回 `healthCheck()` 失敗 → 全ページで接続エラー表示
+   - User Impact: 「バックエンドサーバーが起動していません。`uvx insight-blueprint` を実行してください」
+
+## Testing Strategy
+
+### Unit Testing
+
+SPEC-4b ではフロントエンド単体テストを実装しない。
+
+**根拠**: このフロントエンドの責務は「API を呼んで表示する」のみであり、ビジネスロジックは
+全て Python バックエンド側にある。SPEC-4a の 341 テストがビジネスロジックを十分にカバーしている。
+フロントエンドのユニットテストを書いても ROI が低い。
+
+### Integration Testing
+
+**手動検証チェックリスト**（各タブの基本操作を手動で確認）:
+- Designs: 一覧表示 → フィルタ → 作成 → 詳細展開 → レビュー → コメント → 知識抽出
+- Catalog: ソース一覧 → スキーマ表示 → ソース追加 → 検索 → 知識表示
+- Rules: コンテキスト表示 → Cautions 検索
+- History: タイムライン表示 → レビュー履歴展開
+
+### End-to-End Testing
+
+v1 では Playwright 等の自動 E2E テストは実装しない。
+将来的にリグレッション頻度が上がった段階で導入を検討する。
+
+### Build Verification
+
+- `npm run build` が TypeScript コンパイルエラーゼロで完了すること
+- `poe build-frontend` で `src/insight_blueprint/static/` にビルド成果物が出力されること
+- ビルド済みの SPA が FastAPI の StaticFiles mount で正しく配信されること
+
+## Known Constraints
+
+### Vite Dev Server と FastAPI の分離
+
+開発時は Vite dev server (port 5173) と FastAPI (port 3000) を別プロセスで起動する必要がある。
+Vite proxy (`/api/*` → `localhost:3000`) により CORS を回避する。
+
+本番時は `npm run build` で `static/` にビルドし、FastAPI が同一オリジンで配信する。
+
+### shadcn/ui + Tailwind CSS v4
+
+shadcn/ui は Tailwind CSS v4 と完全互換。ただし v3 とは設定方法が異なる:
+- `tailwind.config.js` は不要（CSS `@theme {}` ブロックで設定）
+- `@tailwind` ディレクティブは廃止（`@import "tailwindcss"` に統一）
+- `npx shadcn@latest init` で v4 対応設定が自動生成される
+- `@` パスエイリアスが `tsconfig.json` と `vite.config.ts` の両方に必要
+
+### dict フィールドの表示
+
+`Design.metrics`, `Design.explanatory`, `Design.chart`, `Design.next_action`,
+`DataSource.connection` は Python 側で untyped dict。フロントエンドでは `JsonTree`
+コンポーネントで汎用的に表示する。構造固有の UI は v1 では作らない。

--- a/.spec-workflow/specs/SPEC-4b/requirements.md
+++ b/.spec-workflow/specs/SPEC-4b/requirements.md
@@ -1,0 +1,285 @@
+# SPEC-4b: webui-frontend — Requirements
+
+> **Spec ID**: SPEC-4b
+> **Feature Name**: webui-frontend
+> **Status**: draft
+> **Created**: 2026-02-28
+> **Depends On**: SPEC-4a (webui-backend)
+
+---
+
+## Introduction
+
+SPEC-4a で構築した REST API (18 endpoints) を消費する React フロントエンドを実装する。
+4タブダッシュボード（Designs / Catalog / Rules / History）により、データサイエンティストが
+ブラウザから分析設計の管理・レビュー・ドメイン知識の閲覧を行えるようにする。
+
+## Alignment with Product Vision
+
+- **MCP + WebUI によるEDA支援**: CLI (MCP) だけでなくブラウザからも同じ操作が可能になり、
+  非エンジニアのアナリストにもアクセスしやすい GUI を提供する
+- **Zero-install (`uvx insight-blueprint`)**: Vite でビルドした成果物を `static/` に配置し、
+  SPEC-4a のビルドパイプライン（hatch artifacts）で wheel に同梱。エンドユーザーに Node.js 不要
+- **Roadmap 進行**: SPEC-4b 完了で WebUI が全機能利用可能になり、SPEC-5 (skills-distribution)
+  への前提条件を満たす
+
+## Requirements
+
+### Requirement 1: Application Shell & Navigation
+
+**User Story:** データサイエンティストとして、ブラウザでダッシュボードを開いたとき、
+4つのタブ（Designs / Catalog / Rules / History）を切り替えて各機能にアクセスしたい。
+
+**FR-1: Application Shell**
+- `App.tsx` にヘッダー（アプリ名 "Insight Blueprint"）+ タブバー + メインコンテンツ領域を配置
+- タブは Designs / Catalog / Rules / History の4つ
+- 初期表示タブは Designs
+
+**FR-2: Tab Navigation**
+- タブ切り替えは `useState` で管理（react-router 不要）
+- URL の `?tab=` パラメータでタブ状態を保持（ブラウザリロード時に復元）
+- タブ切り替え時に URL パラメータを更新（`history.replaceState`）
+
+**FR-3: API Client Layer**
+- `api/client.ts` に全 REST API 呼び出し関数を集約
+- ベース URL は空文字列（同一オリジン配信）
+- 開発時は Vite proxy で `/api/*` を FastAPI (localhost:3000) に転送
+- エラーレスポンス (`{error: string}`) を統一的にハンドリング
+- 全関数に TypeScript 型定義（`types/api.ts`）
+
+**FR-4: Shared UI Components**
+- `DataTable`: 汎用テーブルコンポーネント（shadcn/ui Table ベース）
+- `StatusBadge`: `DesignStatus` の値に応じた色付きバッジ
+- `EmptyState`: データ0件時のプレースホルダ表示
+- `ErrorBanner`: API エラーの統一表示（shadcn/ui Alert ベース）
+
+#### Acceptance Criteria
+
+1. WHEN ブラウザで `/` を開く THEN ヘッダー + 4タブ + Designs タブ内容が表示される
+2. WHEN タブを切り替える THEN 対応するページコンテンツが表示される
+3. WHEN `?tab=catalog` 付きで URL を開く THEN Catalog タブが初期表示される
+4. WHEN API 呼び出しが失敗する THEN `ErrorBanner` でエラーメッセージが表示される
+5. WHEN データが0件 THEN `EmptyState` が表示される
+
+### Requirement 2: Designs Tab (Master-Detail)
+
+**User Story:** データサイエンティストとして、分析設計の一覧を見て、選択した設計の
+詳細・レビュー・知識抽出を1つの画面で操作したい。
+
+**FR-5: Design List (Master)**
+- `GET /api/designs` で全デザイン一覧を取得・表示
+- ステータスフィルタ（All / draft / active / pending_review / supported / rejected / inconclusive）
+- 各行に: タイトル、ステータスバッジ、更新日時
+- 行クリックで詳細パネルを展開
+
+**FR-6: Design Detail (Detail)**
+- `GET /api/designs/{id}` で選択デザインの詳細を取得
+- 表示項目: title, hypothesis_statement, hypothesis_background, status, theme_id,
+  metrics, explanatory, chart, source_ids, next_action, created_at, updated_at
+- `metrics`, `explanatory`, `chart`, `next_action` は JSON ツリー表示（折りたたみ可能）
+
+**FR-7: Design Create**
+- "New Design" ボタンでダイアログ（shadcn/ui Dialog）を開く
+- 入力: title (必須), hypothesis_statement (必須), hypothesis_background (必須),
+  theme_id (任意、デフォルト "DEFAULT")
+- `POST /api/designs` で作成、成功後にリストを再取得
+
+**FR-8: Design Sub-tabs**
+- 詳細パネル内にサブタブ: Overview / Review / Knowledge
+- **Overview**: FR-6 の詳細情報表示
+- **Review**: FR-9, FR-10 のレビュー機能
+- **Knowledge**: FR-11 の知識抽出機能
+
+**FR-9: Review — Submit & Comments**
+- "Submit for Review" ボタン: `POST /api/designs/{id}/review`（status が `active` の場合のみ有効）
+- コメント一覧: `GET /api/designs/{id}/comments` でレビューコメントを時系列表示
+- 各コメント: reviewer, comment, status_after (バッジ), created_at
+
+**FR-10: Review — Add Comment**
+- コメント追加フォーム: comment (テキストエリア), status (セレクト), reviewer (任意)
+- status の選択肢: supported / rejected / inconclusive / active
+- `POST /api/designs/{id}/comments` で送信、成功後にコメントリストを再取得
+
+**FR-11: Knowledge — Extract & Save**
+- "Extract Knowledge" ボタン: `POST /api/designs/{id}/knowledge` (body なし) でプレビュー取得
+- プレビュー表示: 抽出されたエントリ一覧（key, title, content, category, importance）
+- "Save Knowledge" ボタン: `POST /api/designs/{id}/knowledge` (body あり) で保存
+- 保存成功後に確認メッセージ表示
+
+#### Acceptance Criteria
+
+1. WHEN Designs タブを開く THEN 全デザイン一覧がテーブルに表示される
+2. WHEN ステータスフィルタを選択する THEN 該当ステータスのデザインのみ表示される
+3. WHEN デザイン行をクリックする THEN 詳細パネルが展開し Overview サブタブが表示される
+4. WHEN "New Design" ボタンをクリックする THEN 作成ダイアログが開く
+5. WHEN 必須項目を入力して送信する THEN デザインが作成され一覧に反映される
+6. WHEN Review サブタブを開く THEN コメント一覧と操作ボタンが表示される
+7. WHEN active なデザインで "Submit for Review" THEN ステータスが pending_review に変わる
+8. WHEN コメントを追加する THEN コメントリストに反映され、デザインのステータスが更新される
+9. WHEN "Extract Knowledge" をクリックする THEN 抽出プレビューが表示される
+10. WHEN "Save Knowledge" をクリックする THEN 知識エントリが保存され確認が表示される
+11. WHEN 非 active なデザインで "Submit for Review" THEN ボタンが無効化されている
+
+### Requirement 3: Catalog Tab
+
+**User Story:** データサイエンティストとして、登録されたデータソースの一覧・スキーマ・
+ドメイン知識を閲覧し、新しいソースを追加したい。
+
+**FR-12: Source List**
+- `GET /api/catalog/sources` でソース一覧を取得・表示
+- 各行に: name, type (バッジ), description, tags, updated_at
+- 行クリックで詳細（スキーマ）を表示
+
+**FR-13: Source Detail — Schema**
+- `GET /api/catalog/sources/{id}/schema` でカラムスキーマを取得
+- テーブル表示: name, type, description, nullable, unit, examples
+
+**FR-14: Source Add**
+- "Add Source" ボタンでダイアログを開く
+- 入力: source_id (必須), name (必須), type (セレクト: csv/api/sql), description (必須),
+  connection (JSON エディタ)
+- `POST /api/catalog/sources` で追加、成功後にリストを再取得
+
+**FR-15: Catalog Search**
+- 検索バー: `GET /api/catalog/search?q={query}` で全文検索
+- 結果表示: マッチしたカラム・ソース情報
+- ソースフィルタ（任意）: `&source_id=` で絞り込み
+
+**FR-16: Domain Knowledge List**
+- `GET /api/catalog/knowledge` で全ドメイン知識エントリを取得・表示
+- 各エントリ: key, title, content, category (バッジ), importance (バッジ), affects_columns
+
+#### Acceptance Criteria
+
+1. WHEN Catalog タブを開く THEN ソース一覧がテーブルに表示される
+2. WHEN ソース行をクリックする THEN カラムスキーマがテーブルに表示される
+3. WHEN "Add Source" で有効な情報を入力して送信する THEN ソースが追加され一覧に反映される
+4. WHEN 検索バーにクエリを入力する THEN 全文検索結果が表示される
+5. WHEN ドメイン知識セクションを表示する THEN 全エントリが category・importance 付きで表示される
+
+### Requirement 4: Rules Tab
+
+**User Story:** データサイエンティストとして、蓄積されたドメイン知識・ルール・注意事項を
+一覧で確認し、特定テーブルに関連する注意事項を検索したい。
+
+**FR-17: Project Context**
+- `GET /api/rules/context` でプロジェクトコンテキストを取得・表示
+- 3セクション構成:
+  - Sources: ソース一覧サマリー（total_sources 件）
+  - Knowledge: ドメイン知識一覧（total_knowledge 件）
+  - Rules: ルール一覧（total_rules 件）
+
+**FR-18: Cautions Search**
+- テーブル名入力フィールド（カンマ区切り）
+- "Search Cautions" ボタン: `GET /api/rules/cautions?table_names={names}`
+- 結果表示: 該当する注意事項の一覧
+
+#### Acceptance Criteria
+
+1. WHEN Rules タブを開く THEN プロジェクトコンテキスト（Sources / Knowledge / Rules）が表示される
+2. WHEN テーブル名を入力して検索する THEN 関連する注意事項が表示される
+3. WHEN 知識エントリが0件 THEN EmptyState が表示される
+
+### Requirement 5: History Tab
+
+**User Story:** データサイエンティストとして、最近のデザイン変更やレビュー活動を
+時系列で確認し、プロジェクト全体の進捗を把握したい。
+
+**FR-19: Recent Activity Timeline**
+- `GET /api/designs` で全デザインを取得し、`updated_at` の降順でソート表示
+- 各エントリ: title, status (バッジ), updated_at
+- 「更新日」と「作成日」を区別表示
+
+**FR-20: Design Review History**
+- タイムラインのエントリをクリックすると、該当デザインのレビューコメント履歴を展開
+- `GET /api/designs/{id}/comments` でコメントを取得
+- コメントごとに status_after の遷移を表示（ステータス変更のタイムライン）
+
+#### Acceptance Criteria
+
+1. WHEN History タブを開く THEN 全デザインが更新日時の降順で表示される
+2. WHEN エントリをクリックする THEN レビューコメント履歴が展開される
+3. WHEN デザインが0件 THEN EmptyState が表示される
+
+### Requirement 6: shadcn/ui Integration & Build
+
+**User Story:** 開発者として、shadcn/ui コンポーネントを Tailwind CSS v4 環境で使用し、
+一貫性のある UI を構築したい。
+
+**FR-21: shadcn/ui Setup**
+- `npx shadcn@latest init` で shadcn/ui を初期化
+- Tailwind CSS v4 対応の設定（CSS variables ベース）
+- 使用コンポーネント: Tabs, Table, Badge, Button, Card, Dialog, Input, Textarea, Select, Alert
+
+**FR-22: Development Server**
+- `npm run dev` で Vite 開発サーバー起動（HMR 対応）
+- Vite proxy: `/api/*` → `http://localhost:3000/api/*`（FastAPI バックエンド）
+- 開発中は FastAPI (`uvx insight-blueprint`) と Vite dev server を別プロセスで起動
+
+**FR-23: Production Build**
+- `npm run build` で `src/insight_blueprint/static/` にビルド成果物を出力
+- 既存の `poe build-frontend` タスクとの互換性を維持
+- ビルド成果物は SPA 構成（`index.html` + JS/CSS バンドル）
+
+#### Acceptance Criteria
+
+1. WHEN `npm run dev` THEN Vite 開発サーバーが起動し HMR が動作する
+2. WHEN 開発サーバーから `/api/health` にアクセスする THEN FastAPI の応答が proxy 経由で返る
+3. WHEN `npm run build` THEN `src/insight_blueprint/static/` にビルド成果物が出力される
+4. WHEN shadcn/ui コンポーネントを使用する THEN Tailwind CSS v4 のスタイルが正しく適用される
+5. WHEN `poe build-frontend` THEN 既存パイプラインでビルドが成功する
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+
+- **Single Responsibility**: 1ファイル = 1コンポーネント or 1モジュール
+- **ファイル構成**: `pages/` (ページコンポーネント), `components/` (共通UI),
+  `api/` (APIクライアント), `types/` (型定義) の4ディレクトリ
+- **Component Isolation**: 各ページコンポーネントは自身の API 呼び出しと状態を持つ。
+  ページ間で状態を共有しない
+- **TypeScript strict mode**: `tsconfig.json` で `strict: true`
+- 1ファイルあたり 200-400 行（最大 800 行）
+
+### Performance
+
+- 初期ロード: 3秒以内（localhost、ビルド済み static 配信時）
+- タブ切り替え: 即座に描画（クライアントサイドのみ）
+- API 呼び出し: SPEC-4a の 100ms 以内 + ネットワーク遅延（localhost なので無視可能）
+- Vite ビルド: 30秒以内
+
+### Security
+
+- API 呼び出しは同一オリジン（localhost）のみ
+- ユーザー入力は API リクエスト送信前にフロントエンドでバリデーション
+- XSS 防止: React のデフォルトエスケーピングに依存（`dangerouslySetInnerHTML` 禁止）
+- `connection` フィールドの JSON 入力: パース可能性の検証のみ（内容のバリデーションはバックエンド）
+
+### Reliability
+
+- API エラー時は `ErrorBanner` で表示（クラッシュしない）
+- ネットワークエラー時は再試行ボタンを表示
+- バックエンド未起動時は接続エラーメッセージを表示
+- TypeScript コンパイルエラーゼロ
+
+### Usability
+
+- 日本語 UI（ラベル、プレースホルダ、エラーメッセージ）
+- レスポンシブレイアウト（最小幅 1024px）
+- ステータスバッジのカラーコーディング:
+  draft=gray, active=blue, pending_review=yellow, supported=green, rejected=red, inconclusive=orange
+- ローディング状態の表示（スピナー or スケルトン）
+- フォームバリデーション: 必須項目の未入力時にインラインエラー表示
+
+## Out of Scope
+
+- WebSocket / リアルタイム更新（v1 はページ操作時の再取得で十分）
+- 認証・認可（localhost シングルユーザー）
+- ダークモード（v1 はライトモードのみ）
+- i18n / 多言語対応（v1 は日本語固定）
+- モバイル対応（最小幅 1024px、デスクトップ前提）
+- フロントエンド単体テスト（ビジネスロジックは Python 側の 341 テストでカバー済み）
+- デザインの編集（PUT /api/designs/{id}）— v1 は作成・閲覧・レビューに集中
+- ソースの編集（PUT /api/catalog/sources/{id}）— v1 は追加・閲覧に集中
+- ページネーション（データセットが小規模）
+- オフライン対応

--- a/.spec-workflow/specs/SPEC-4b/tasks.md
+++ b/.spec-workflow/specs/SPEC-4b/tasks.md
@@ -1,0 +1,313 @@
+# SPEC-4b: webui-frontend — Tasks
+
+- [x] 1.1 Initialize shadcn/ui and configure development environment
+  - File: `frontend/package.json`, `frontend/tsconfig.json`, `frontend/vite.config.ts`, `frontend/src/index.css`, `frontend/components.json`
+  - Run `npx shadcn@latest init` in `frontend/` with CSS Variables enabled
+  - Add `@` path alias to `tsconfig.json` (`paths: {"@/*": ["./src/*"]}`) and `vite.config.ts` (`resolve.alias`)
+  - Add Vite proxy config: `server.proxy["/api"] = { target: "http://localhost:3000", changeOrigin: true }`
+  - Install required shadcn/ui components: `npx shadcn@latest add tabs table badge button card dialog input textarea select alert`
+  - Purpose: Establish the frontend development environment with all UI dependencies before any component work begins
+  - Done When:
+    1. `frontend/components.json` が存在し shadcn/ui 設定が記載されている
+    2. `tsconfig.json` に `@/*` パスエイリアスが設定されている
+    3. `vite.config.ts` に `resolve.alias` と `server.proxy` が設定されている
+    4. 10個の shadcn/ui コンポーネントが `frontend/src/components/ui/` に存在する
+    5. `npm run dev` がエラーなく起動する
+    6. `npm run build` が `src/insight_blueprint/static/` にファイルを出力する
+  - Verify:
+    1. `ls frontend/src/components/ui/ | wc -l` → 10以上
+    2. `cd frontend && npx tsc --noEmit` → exit 0
+    3. `cd frontend && npm run build` → exit 0
+    4. `ls src/insight_blueprint/static/index.html` → ファイル存在
+    5. `grep '@/' frontend/tsconfig.json` → パスエイリアス確認
+    6. `grep 'proxy' frontend/vite.config.ts` → proxy 設定確認
+  - _Leverage: existing `frontend/` scaffold (Vite 6 + React 19 + Tailwind CSS v4), `.claude/docs/research/SPEC-4b-frontend-research.md`_
+  - _Requirements: FR-21, FR-22, FR-23_
+  - _Prompt: Role: Frontend Developer specializing in React + Vite + Tailwind CSS v4 + shadcn/ui setup | Task: Implement the task for spec SPEC-4b, first run spec-workflow-guide to get the workflow guide then implement the task: Initialize shadcn/ui in the existing frontend scaffold. Add path alias, Vite proxy, and install all 10 shadcn/ui components. Verify dev server and production build both work. | Restrictions: Do not modify any Python files. Do not change the Vite build output directory (must remain `../src/insight_blueprint/static`). Do not add unnecessary dependencies. | Success: `npm run dev` starts without errors, `npm run build` produces output in `src/insight_blueprint/static/`, all 10 shadcn/ui components are installed, path alias `@/` resolves correctly. Mark task as in-progress `[-]` in tasks.md before starting, log implementation with log-implementation tool after completion, then mark as complete `[x]`._
+
+- [x] 1.2 Create TypeScript type definitions and API client
+  - File: `frontend/src/types/api.ts`, `frontend/src/api/client.ts`
+  - Define all TypeScript types mirroring Python Pydantic models: `Design`, `DataSource`, `ColumnSchema`, `ReviewComment`, `KnowledgeEntry`, `RulesContext`, `SearchResult`, `Caution`
+  - Define enum union types: `DesignStatus`, `SourceType`, `KnowledgeCategory`, `KnowledgeImportance`
+  - Define request types: `CreateDesignRequest`, `AddCommentRequest`, `AddSourceRequest`
+  - Implement `request\<T>()` shared helper with: JSON/non-JSON error handling, 422 normalization, AbortError passthrough, network error handling
+  - Implement all 16 endpoint functions (excluding PUT endpoints per Out of Scope), each accepting optional `AbortSignal`
+  - Purpose: Establish the type-safe API layer that all page components depend on
+  - Done When:
+    1. `frontend/src/types/api.ts` に 8 モデル型 + 4 enum 型 + 3 リクエスト型が定義されている
+    2. `frontend/src/api/client.ts` に `request\<T>()` ヘルパーが実装されている
+    3. `client.ts` に 16 エンドポイント関数が実装されている
+    4. 全 GET 関数が `AbortSignal` パラメータを受け取る
+    5. `npx tsc --noEmit` がエラーゼロで通過する
+  - Verify:
+    1. `cd frontend && npx tsc --noEmit` → exit 0
+    2. `grep -c 'export type\|export interface' src/types/api.ts` → 15以上
+    3. `grep -c 'export async function' src/api/client.ts` → 16
+    4. `grep -c 'AbortSignal' src/api/client.ts` → GET 関数の数以上
+    5. `grep 'request\<' src/api/client.ts` → request ヘルパーの存在確認
+  - _Leverage: SPEC-4a `web.py` endpoint definitions, `models/design.py`, `models/catalog.py`, `models/review.py`_
+  - _Requirements: FR-3, NFR-Security (XSS prevention via type safety)_
+  - _Prompt: Role: TypeScript Developer specializing in API client design and type safety | Task: Implement the task for spec SPEC-4b, first run spec-workflow-guide to get the workflow guide then implement the task: Create complete TypeScript type definitions mirroring Python Pydantic models, and implement the API client with shared request\<T>() helper. Reference SPEC-4a web.py for exact endpoint signatures and response shapes. | Restrictions: Do not use any external HTTP client library (use native fetch). Do not add runtime type validation (trust backend contracts). Base URL must be empty string (same-origin serving). Include AbortSignal parameter on all GET endpoint functions. | Success: All types compile without errors, all 16 endpoint functions implemented, request\<T>() handles {error}, {detail} (422), non-JSON, and network errors correctly. Mark task as in-progress `[-]` in tasks.md before starting, log implementation with log-implementation tool after completion, then mark as complete `[x]`._
+
+- [x] 2.1 Create shared UI components
+  - File: `frontend/src/components/DataTable.tsx`, `frontend/src/components/StatusBadge.tsx`, `frontend/src/components/EmptyState.tsx`, `frontend/src/components/ErrorBanner.tsx`, `frontend/src/components/JsonTree.tsx`
+  - `DataTable\<T>`: generic table with columns config, row click handler, selected row highlight. Wraps shadcn/ui Table
+  - `StatusBadge`: DesignStatus → color mapping (draft=gray, active=blue, pending_review=yellow, supported=green, rejected=red, inconclusive=orange). Wraps shadcn/ui Badge
+  - `EmptyState`: message + optional action button
+  - `ErrorBanner`: error message + optional retry button. Wraps shadcn/ui Alert
+  - `JsonTree`: recursive collapsible JSON viewer for dict fields (metrics, connection, etc.). No external library
+  - Purpose: Provide reusable UI building blocks used across 4+ pages
+  - Done When:
+    1. 5つのコンポーネントファイルが `frontend/src/components/` に存在する
+    2. 各コンポーネントが 100行以内である
+    3. `DataTable` が TypeScript ジェネリクスを使用している
+    4. `StatusBadge` が 6つの DesignStatus 値すべてに色をマッピングしている
+    5. `npx tsc --noEmit` がエラーゼロで通過する
+  - Verify:
+    1. `cd frontend && npx tsc --noEmit` → exit 0
+    2. `ls src/components/{DataTable,StatusBadge,EmptyState,ErrorBanner,JsonTree}.tsx | wc -l` → 5
+    3. `wc -l src/components/DataTable.tsx` → 100行以下
+    4. `grep -c 'draft\|active\|pending_review\|supported\|rejected\|inconclusive' src/components/StatusBadge.tsx` → 6
+    5. `grep 'T extends\|<T>' src/components/DataTable.tsx` → ジェネリクス使用確認
+  - _Leverage: shadcn/ui components installed in task 1.1_
+  - _Requirements: FR-4, NFR-Usability (color coding, loading states)_
+  - _Prompt: Role: React Component Developer specializing in reusable UI components | Task: Implement the task for spec SPEC-4b, first run spec-workflow-guide to get the workflow guide then implement the task: Create 5 shared UI components using shadcn/ui primitives. DataTable must be generic with TypeScript generics. StatusBadge must map all 6 DesignStatus values to specific colors. JsonTree must handle nested objects/arrays with expand/collapse. | Restrictions: Do not use external component libraries beyond shadcn/ui. Keep each component under 100 lines. Do not add global CSS — use Tailwind utility classes only. | Success: All 5 components render correctly, DataTable accepts generic type parameter, StatusBadge shows correct colors for all 6 statuses, JsonTree handles nested data with toggle. Mark task as in-progress `[-]` in tasks.md before starting, log implementation with log-implementation tool after completion, then mark as complete `[x]`._
+
+- [x] 2.2 Create App shell with tab navigation
+  - File: `frontend/src/App.tsx`, `frontend/src/main.tsx`
+  - Implement App shell: header ("Insight Blueprint") + shadcn/ui Tabs for 4 tabs
+  - Tab state management: useState\<Tab> synced with URL ?tab= parameter
+  - Handle popstate event for browser back/forward navigation
+  - Invalid ?tab= values fallback to "designs"
+  - Update main.tsx to render App instead of placeholder
+  - Purpose: Establish the application shell that hosts all page components
+  - Done When:
+    1. `App.tsx` が 4タブ（Designs/Catalog/Rules/History）を表示する
+    2. タブクリックで URL の `?tab=` パラメータが更新される
+    3. `?tab=invalid` がデフォルトの "designs" にフォールバックする
+    4. popstate イベントハンドラが登録されている
+    5. `main.tsx` が App コンポーネントをレンダーする
+    6. `npx tsc --noEmit` がエラーゼロで通過する
+  - Verify:
+    1. `cd frontend && npx tsc --noEmit` → exit 0
+    2. `cd frontend && npm run build` → exit 0
+    3. `grep 'popstate' src/App.tsx` → イベントハンドラ存在
+    4. `grep 'designs.*catalog.*rules.*history' src/App.tsx` → 4タブ定義確認（大文字小文字問わず）
+    5. `grep 'replaceState\|pushState' src/App.tsx` → URL 同期処理確認
+  - _Leverage: shadcn/ui Tabs component_
+  - _Requirements: FR-1, FR-2_
+  - _Prompt: Role: React Developer specializing in SPA navigation and URL state sync | Task: Implement the task for spec SPEC-4b, first run spec-workflow-guide to get the workflow guide then implement the task: Create App.tsx with header, 4-tab navigation using shadcn/ui Tabs, and URL ?tab= synchronization. Handle popstate for browser navigation. Render placeholder content for each tab (actual pages will be implemented in later tasks). Update main.tsx entry point. | Restrictions: Do not use react-router. Use history.replaceState (not pushState) for tab changes. Keep App.tsx under 80 lines. | Success: 4 tabs render and switch correctly, URL updates on tab change, page reload preserves tab selection, browser back/forward works, invalid ?tab= falls back to designs. Mark task as in-progress `[-]` in tasks.md before starting, log implementation with log-implementation tool after completion, then mark as complete `[x]`._
+
+- [x] 3.1 Implement Designs page (master list + create dialog)
+  - File: `frontend/src/pages/DesignsPage.tsx`
+  - Fetch and display design list using DataTable with columns: title, status (StatusBadge), updated_at
+  - Status filter dropdown (All + 6 status values) using shadcn/ui Select
+  - "New Design" button → Dialog with form: title, hypothesis_statement, hypothesis_background, theme_id
+  - Loading state, error handling (ErrorBanner), empty state (EmptyState)
+  - AbortController in useEffect for list fetch, cleanup on unmount/filter change
+  - Row click sets selectedId state, renders DesignDetail below (placeholder until 3.2)
+  - Purpose: Implement the master half of the Designs master-detail view
+  - Done When:
+    1. `DesignsPage.tsx` が存在し 250行以内である
+    2. `listDesigns` API を呼び出してデザイン一覧を表示する
+    3. ステータスフィルタ（All + 6 status）が動作する
+    4. "New Design" ダイアログが開き、送信後にリスト更新される
+    5. Loading/Error/Empty の3状態が実装されている
+    6. useEffect 内で AbortController を使用している
+    7. `npx tsc --noEmit` がエラーゼロで通過する
+  - Verify:
+    1. `cd frontend && npx tsc --noEmit` → exit 0
+    2. `wc -l src/pages/DesignsPage.tsx` → 250行以下
+    3. `grep 'AbortController' src/pages/DesignsPage.tsx` → 存在確認
+    4. `grep 'listDesigns\|createDesign' src/pages/DesignsPage.tsx` → API 呼び出し確認
+    5. `grep 'ErrorBanner\|EmptyState' src/pages/DesignsPage.tsx` → エラー/空状態確認
+    6. `grep 'Dialog' src/pages/DesignsPage.tsx` → 作成ダイアログ確認
+  - _Leverage: `api/client.ts` (listDesigns, createDesign), shared components (DataTable, StatusBadge, EmptyState, ErrorBanner)_
+  - _Requirements: FR-5, FR-7_
+  - _Prompt: Role: React Developer specializing in data-driven UI with forms and filtering | Task: Implement the task for spec SPEC-4b, first run spec-workflow-guide to get the workflow guide then implement the task: Create DesignsPage with design list table, status filter, and create dialog. Use AbortController for fetch cancellation. Connect to API client for listDesigns and createDesign. | Restrictions: Do not implement the detail panel yet (that is task 3.2). Do not use any state management library. Keep the file under 250 lines. | Success: Design list loads and displays, status filter works, create dialog opens/submits/refreshes list, loading/error/empty states render correctly, AbortController cancels stale requests. Mark task as in-progress `[-]` in tasks.md before starting, log implementation with log-implementation tool after completion, then mark as complete `[x]`._
+
+- [x] 3.2 Implement Design detail with sub-tabs (Overview / Review / Knowledge)
+  - File: `frontend/src/pages/DesignDetail.tsx`
+  - Fetch design detail via getDesign(designId)
+  - Sub-tabs using shadcn/ui Tabs: Overview, Review, Knowledge
+  - **OverviewPanel**: display all design fields, JsonTree for dict fields (metrics, explanatory, chart, next_action)
+  - **ReviewPanel**: "Submit for Review" button (disabled when status !== "active"), comments list (DataTable), add comment form (textarea + status select + reviewer input)
+  - **KnowledgePanel**: "Extract Knowledge" button → preview list, "Save Knowledge" button → persist
+  - onDesignUpdated callback to trigger parent list refresh
+  - Purpose: Implement the detail half of the Designs master-detail view with full review workflow
+  - Done When:
+    1. `DesignDetail.tsx` が存在し 400行以内である
+    2. Overview / Review / Knowledge の3サブタブが実装されている
+    3. OverviewPanel が dict フィールドに JsonTree を使用している
+    4. ReviewPanel の "Submit for Review" ボタンが status !== "active" 時に無効化される
+    5. KnowledgePanel の "Extract Knowledge" + "Save Knowledge" が実装されている
+    6. `onDesignUpdated` コールバックが親に変更を通知する
+    7. `npx tsc --noEmit` がエラーゼロで通過する
+  - Verify:
+    1. `cd frontend && npx tsc --noEmit` → exit 0
+    2. `wc -l src/pages/DesignDetail.tsx` → 400行以下
+    3. `grep 'Overview\|Review\|Knowledge' src/pages/DesignDetail.tsx` → 3サブタブ確認
+    4. `grep 'disabled\|status.*active' src/pages/DesignDetail.tsx` → ボタン無効化ロジック確認
+    5. `grep 'JsonTree' src/pages/DesignDetail.tsx` → JsonTree 使用確認
+    6. `grep 'onDesignUpdated' src/pages/DesignDetail.tsx` → コールバック確認
+  - _Leverage: `api/client.ts` (getDesign, submitReview, listComments, addComment, extractKnowledge, saveKnowledge), shared components (JsonTree, DataTable, StatusBadge)_
+  - _Requirements: FR-6, FR-8, FR-9, FR-10, FR-11_
+  - _Prompt: Role: React Developer specializing in complex multi-panel UI with forms | Task: Implement the task for spec SPEC-4b, first run spec-workflow-guide to get the workflow guide then implement the task: Create DesignDetail with 3 sub-tabs (Overview/Review/Knowledge). Each panel is a separate function component within the same file. Overview shows design fields with JsonTree for dicts. Review has submit button, comment list, and add comment form. Knowledge has extract preview and save functionality. | Restrictions: Keep DesignDetail as orchestrator (~150 lines) with panels (~60-80 lines each). Do not exceed 400 lines total. Disable "Submit for Review" when status is not "active". Use AbortController for all fetches. | Success: All 3 sub-tabs render with correct data, review submit changes status, comments add and refresh, knowledge extract shows preview and save persists, parent list refreshes on updates. Mark task as in-progress `[-]` in tasks.md before starting, log implementation with log-implementation tool after completion, then mark as complete `[x]`._
+
+- [x] 3.3 Wire DesignsPage + DesignDetail together
+  - File: `frontend/src/pages/DesignsPage.tsx` (modify), `frontend/src/App.tsx` (modify)
+  - Import and render DesignDetail in DesignsPage when selectedId is set
+  - Pass onDesignUpdated callback to refresh design list
+  - Wire DesignsPage into App.tsx tab content (replace placeholder)
+  - Purpose: Complete the Designs tab by connecting master and detail components
+  - Done When:
+    1. DesignsPage が `selectedId` 設定時に DesignDetail をレンダーする
+    2. `onDesignUpdated` コールバックでデザインリストが再取得される
+    3. App.tsx の Designs タブが DesignsPage を表示する
+    4. `npx tsc --noEmit` がエラーゼロで通過する
+  - Verify:
+    1. `cd frontend && npx tsc --noEmit` → exit 0
+    2. `cd frontend && npm run build` → exit 0
+    3. `grep 'DesignDetail' src/pages/DesignsPage.tsx` → import + render 確認
+    4. `grep 'DesignsPage' src/App.tsx` → import 確認
+  - _Leverage: DesignsPage (task 3.1), DesignDetail (task 3.2)_
+  - _Requirements: FR-5, FR-6, FR-8_
+  - _Prompt: Role: React Developer | Task: Implement the task for spec SPEC-4b, first run spec-workflow-guide to get the workflow guide then implement the task: Wire DesignDetail into DesignsPage (render below table when selectedId is set). Wire DesignsPage into App.tsx Designs tab. | Restrictions: Minimal changes only — import + render + callback wiring. Do not refactor existing components. | Success: Clicking a design row shows DesignDetail below, design updates refresh the list, Designs tab in App.tsx shows the full page. Mark task as in-progress `[-]` in tasks.md before starting, log implementation with log-implementation tool after completion, then mark as complete `[x]`._
+
+- [x] 4.1 Implement Catalog page
+  - File: `frontend/src/pages/CatalogPage.tsx`
+  - Source list with DataTable: name, type (badge), description, tags, updated_at
+  - Source detail: schema table (ColumnSchema fields) on row click
+  - "Add Source" dialog: source_id, name, type (select), description, connection (JSON textarea)
+  - Search bar: input + search button, results display
+  - Domain knowledge list section
+  - Internal sub-components: SourceListSection, SchemaSection, SearchSection, KnowledgeSection
+  - AbortController for all fetches
+  - Purpose: Implement the complete Catalog tab with all 4 sections
+  - Done When:
+    1. `CatalogPage.tsx` が存在し 350行以内である
+    2. ソース一覧が DataTable で表示される
+    3. ソースクリックでスキーマテーブルが表示される
+    4. "Add Source" ダイアログで JSON バリデーションが動作する（不正 JSON → エラー表示、正当 JSON → 送信成功）
+    5. 検索バーがカタログ検索を実行し結果を表示する
+    6. ドメイン知識セクションが category/importance バッジ付きで表示される
+    7. `npx tsc --noEmit` がエラーゼロで通過する
+  - Verify:
+    1. `cd frontend && npx tsc --noEmit` → exit 0
+    2. `wc -l src/pages/CatalogPage.tsx` → 350行以下
+    3. `grep 'AbortController' src/pages/CatalogPage.tsx` → 存在確認
+    4. `grep 'JSON.parse' src/pages/CatalogPage.tsx` → JSON バリデーション確認
+    5. `grep 'listSources\|addSource\|getSchema\|searchCatalog\|getKnowledgeList' src/pages/CatalogPage.tsx` → 5 API 呼び出し確認
+    6. `grep 'SourceListSection\|SchemaSection\|SearchSection\|KnowledgeSection' src/pages/CatalogPage.tsx` → 4サブコンポーネント確認
+  - _Leverage: `api/client.ts` (listSources, addSource, getSchema, searchCatalog, getKnowledgeList), shared components_
+  - _Requirements: FR-12, FR-13, FR-14, FR-15, FR-16_
+  - _Prompt: Role: React Developer specializing in multi-section data pages | Task: Implement the task for spec SPEC-4b, first run spec-workflow-guide to get the workflow guide then implement the task: Create CatalogPage with 4 internal sections (SourceList, Schema, Search, Knowledge). Each section is a sub-component in the same file. Source list shows all sources, clicking shows schema. Add Source opens dialog with JSON textarea for connection. Search bar triggers catalog search. Knowledge section shows all domain knowledge entries. | Restrictions: Keep total file under 350 lines. Validate JSON input for connection field before submit. Use AbortController for all fetches. | Success: Source list loads, schema displays on click, add source works with JSON validation, search returns results, knowledge entries display with category/importance badges. Mark task as in-progress `[-]` in tasks.md before starting, log implementation with log-implementation tool after completion, then mark as complete `[x]`._
+
+- [x] 4.2 Implement Rules page
+  - File: `frontend/src/pages/RulesPage.tsx`
+  - Fetch and display project context (GET /api/rules/context) in 3 collapsible sections: Sources, Knowledge, Rules
+  - Each section shows count in header and list/table of items
+  - Cautions search: table names input (comma-separated) + search button
+  - Search results display
+  - Purpose: Implement the Rules tab for domain knowledge and cautions browsing
+  - Done When:
+    1. `RulesPage.tsx` が存在し 200行以内である
+    2. Sources / Knowledge / Rules の3セクションが折りたたみ可能に表示される
+    3. 各セクションヘッダーにアイテム数が表示される
+    4. テーブル名入力 + 検索ボタンで Cautions 検索が動作する
+    5. データなし時に EmptyState が表示される
+    6. `npx tsc --noEmit` がエラーゼロで通過する
+  - Verify:
+    1. `cd frontend && npx tsc --noEmit` → exit 0
+    2. `wc -l src/pages/RulesPage.tsx` → 200行以下
+    3. `grep 'AbortController' src/pages/RulesPage.tsx` → 存在確認
+    4. `grep 'getRulesContext\|getCautions' src/pages/RulesPage.tsx` → 2 API 呼び出し確認
+    5. `grep 'Card' src/pages/RulesPage.tsx` → shadcn/ui Card 使用確認
+  - _Leverage: `api/client.ts` (getRulesContext, getCautions), shared components_
+  - _Requirements: FR-17, FR-18_
+  - _Prompt: Role: React Developer | Task: Implement the task for spec SPEC-4b, first run spec-workflow-guide to get the workflow guide then implement the task: Create RulesPage with project context display (3 collapsible sections with counts) and cautions search form. | Restrictions: Keep file under 200 lines. Use shadcn/ui Card for sections. Use AbortController for fetches. | Success: Context loads with correct counts, sections expand/collapse, cautions search returns results for valid table names, empty state shows when no data. Mark task as in-progress `[-]` in tasks.md before starting, log implementation with log-implementation tool after completion, then mark as complete `[x]`._
+
+- [x] 4.3 Implement History page
+  - File: `frontend/src/pages/HistoryPage.tsx`
+  - Fetch all designs, sort by updated_at descending
+  - Display timeline: title, status (StatusBadge), updated_at, distinguish created vs updated
+  - Click to expand: fetch and show review comments for that design
+  - Comments show reviewer, comment text, status_after (StatusBadge), created_at
+  - Purpose: Implement the History tab using existing API endpoints (no new backend needed)
+  - Done When:
+    1. `HistoryPage.tsx` が存在し 200行以内である
+    2. デザイン一覧が updated_at 降順で表示される
+    3. created と updated が視覚的に区別される
+    4. エントリクリックでレビューコメント履歴が展開される
+    5. コメントに reviewer, comment, status_after, created_at が表示される
+    6. デザイン0件時に EmptyState が表示される
+    7. `npx tsc --noEmit` がエラーゼロで通過する
+  - Verify:
+    1. `cd frontend && npx tsc --noEmit` → exit 0
+    2. `wc -l src/pages/HistoryPage.tsx` → 200行以下
+    3. `grep 'AbortController' src/pages/HistoryPage.tsx` → 存在確認
+    4. `grep 'listDesigns\|listComments' src/pages/HistoryPage.tsx` → 2 API 呼び出し確認
+    5. `grep 'StatusBadge\|EmptyState' src/pages/HistoryPage.tsx` → 共通コンポーネント使用確認
+    6. `grep 'updated_at\|sort' src/pages/HistoryPage.tsx` → ソート処理確認
+  - _Leverage: `api/client.ts` (listDesigns, listComments), shared components (StatusBadge, EmptyState)_
+  - _Requirements: FR-19, FR-20_
+  - _Prompt: Role: React Developer | Task: Implement the task for spec SPEC-4b, first run spec-workflow-guide to get the workflow guide then implement the task: Create HistoryPage showing all designs sorted by updated_at desc as a timeline. Clicking an entry expands to show review comment history fetched via listComments. | Restrictions: Do not create new API endpoints. Keep file under 200 lines. Use AbortController for comment fetches. Distinguish "created" vs "updated" in the timeline display. | Success: Timeline shows all designs sorted by date, clicking expands to show comments with status badges, empty state renders when no designs exist. Mark task as in-progress `[-]` in tasks.md before starting, log implementation with log-implementation tool after completion, then mark as complete `[x]`._
+
+- [x] 5.1 Wire all pages into App and verify full build
+  - File: `frontend/src/App.tsx` (modify)
+  - Import and wire CatalogPage, RulesPage, HistoryPage into App.tsx tab content
+  - Verify `npm run build` succeeds with zero TypeScript errors
+  - Verify `poe build-frontend` produces output in `src/insight_blueprint/static/`
+  - Verify built SPA loads correctly when served by FastAPI StaticFiles
+  - Purpose: Final integration and build verification to ensure the complete dashboard is deployable
+  - Done When:
+    1. App.tsx が 4タブすべてのページコンポーネントを import・レンダーしている
+    2. `npm run build` が TypeScript エラーゼロで完了する
+    3. `poe build-frontend` が `src/insight_blueprint/static/` にファイルを出力する
+    4. ビルド時間が 30秒以内である
+    5. FastAPI 起動時に `GET /` で `index.html` が返る
+    6. SPEC-4a の全 341 テストが通過する（リグレッションなし）
+  - Verify:
+    1. `cd frontend && npx tsc --noEmit` → exit 0
+    2. `cd frontend && npm run build` → exit 0（30秒以内）
+    3. `poe build-frontend` → exit 0
+    4. `ls src/insight_blueprint/static/index.html` → ファイル存在
+    5. `ls src/insight_blueprint/static/assets/` → JS/CSS ファイル存在
+    6. `grep 'CatalogPage\|RulesPage\|HistoryPage\|DesignsPage' frontend/src/App.tsx` → 4ページ import 確認
+    7. `uv run pytest` → 341 tests passed
+  - _Leverage: All page components (tasks 3.1-4.3), existing build pipeline (poe build-frontend)_
+  - _Requirements: FR-23, NFR-Performance (build under 30s)_
+  - _Prompt: Role: Frontend Developer specializing in build systems and integration | Task: Implement the task for spec SPEC-4b, first run spec-workflow-guide to get the workflow guide then implement the task: Wire remaining pages (Catalog, Rules, History) into App.tsx. Run npm run build and poe build-frontend to verify the complete SPA builds successfully. Test that the built static files are served correctly by FastAPI. | Restrictions: Do not modify page components — only App.tsx imports. Do not change build configuration. Ensure zero TypeScript compile errors. | Success: All 4 tabs work in the built SPA, npm run build completes under 30s, poe build-frontend outputs to static/, FastAPI serves the SPA correctly at localhost. Mark task as in-progress `[-]` in tasks.md before starting, log implementation with log-implementation tool after completion, then mark as complete `[x]`._
+
+- [x] 5.2 Set up Playwright smoke tests
+  - File: `frontend/playwright.config.ts`, `frontend/e2e/smoke.spec.ts`, `frontend/package.json` (modify)
+  - Install Playwright: `npm install -D @playwright/test` and `npx playwright install chromium`
+  - Create `playwright.config.ts` with baseURL `http://localhost:3000`, headless mode, webServer config
+  - Implement 8 smoke test cases in `frontend/e2e/smoke.spec.ts`:
+    - S1: Tab routing — navigate all 4 tabs, verify URL ?tab= sync
+    - S2: Invalid tab fallback — `?tab=invalid` → designs
+    - S3: API error banner — load without backend → ErrorBanner visible
+    - S4: Empty state — load with no data → EmptyState visible
+    - S5: Create design dialog — open, fill, submit, verify in list
+    - S6: Status filter — select "draft", verify filtered results
+    - S7: Design detail expand — click row, verify sub-tabs visible
+    - S8: Source add with JSON validation — invalid JSON error, valid JSON success
+  - Add `"test:e2e": "playwright test"` script to package.json
+  - Purpose: Automate high-risk regression detection, runnable by Claude Code via Playwright MCP
+  - Done When:
+    1. `frontend/playwright.config.ts` が存在し baseURL が `http://localhost:3000` に設定されている
+    2. `frontend/e2e/smoke.spec.ts` に 8 テストケースが実装されている
+    3. `package.json` に `test:e2e` スクリプトが追加されている
+    4. `npx playwright test` で 8/8 テストが通過する
+    5. テスト実行時間が 30秒以内である
+    6. flaky test がない（3回連続実行で全パス）
+  - Verify:
+    1. `ls frontend/playwright.config.ts` → ファイル存在
+    2. `ls frontend/e2e/smoke.spec.ts` → ファイル存在
+    3. `grep 'test:e2e' frontend/package.json` → スクリプト存在
+    4. `cd frontend && npx playwright test` → 8 passed（FastAPI + ビルド済み SPA が必要）
+    5. `cd frontend && npx playwright test` を 3回実行 → 全回パス（flaky test なし確認）
+    6. `grep -c 'test(' e2e/smoke.spec.ts` → 8
+  - _Leverage: Built SPA from task 5.1, all page components, Playwright MCP (webapp-testing skill)_
+  - _Requirements: test-design.md Playwright Smoke Tests section_
+  - _Prompt: Role: Frontend Test Engineer specializing in Playwright E2E testing | Task: Implement the task for spec SPEC-4b, first run spec-workflow-guide to get the workflow guide then implement the task: Set up Playwright with 8 smoke tests covering tab routing, error handling, empty states, design CRUD, and source validation. Tests should be concise (each under 20 lines) and reliable. | Restrictions: Only install Playwright (no other test frameworks). Only install chromium browser. Keep all tests in a single file. Tests must work with the built SPA served by FastAPI (not dev server). Do not test Review workflow or Knowledge extraction (these remain manual). | Success: All 8 smoke tests pass with `npx playwright test`, tests complete in under 30 seconds, no flaky tests. Mark task as in-progress `[-]` in tasks.md before starting, log implementation with log-implementation tool after completion, then mark as complete `[x]`._

--- a/.spec-workflow/specs/SPEC-4b/test-design.md
+++ b/.spec-workflow/specs/SPEC-4b/test-design.md
@@ -1,0 +1,264 @@
+# SPEC-4b: webui-frontend — Test Design
+
+> **Spec ID**: SPEC-4b
+> **Status**: draft
+> **Created**: 2026-02-28
+> **Depends On**: SPEC-4a (webui-backend)
+
+---
+
+## Test Architecture
+
+### Test Scope Decision
+
+SPEC-4b はフロントエンド（React SPA）であり、ビジネスロジックは全て Python バックエンド
+（SPEC-4a の 341 テスト）でカバー済み。フロントエンドの責務は「API を呼んで表示する」のみ。
+
+**自動テストの対象外とする理由:**
+- フロントエンド単体テスト（Vitest + Testing Library）: ROI が低い。表示ロジックのみ
+
+**品質担保の手段:**
+1. **TypeScript strict mode** — コンパイルエラーゼロが実装の静的検証
+2. **ビルド検証** — `npm run build` + `poe build-frontend` の成功を CI ゲートに
+3. **Playwright smoke tests** — リグレッションリスクの高い 8 ケースを自動検証（Claude Code + Playwright MCP で実行）
+4. **手動検証チェックリスト** — Playwright でカバーしない操作を手動で確認
+5. **バックエンド API テスト** — SPEC-4a の 341 テストが API 契約を保証
+
+### Test Pyramid
+
+```
+          ┌──────────────┐
+          │  手動検証      │  ← Playwright でカバーしない操作
+          ├──────────────┤
+        ┌─┤ Playwright    ├─┐  ← 8 smoke tests (Claude Code + MCP で実行)
+        │ ├──────────────┤ │
+      ┌─┤  ビルド検証    ├─┐  ← npm run build, poe build-frontend
+      │ ├──────────────┤ │
+  ┌───┴─┴──────────────┴─┴───┐
+  │  TypeScript Compiler (静的) │  ← tsc --noEmit (strict: true)
+  └──────────────────────────┘
+        +
+  ┌──────────────────────────┐
+  │  Backend API Tests (341)  │  ← SPEC-4a pytest (API 契約保証)
+  └──────────────────────────┘
+```
+
+## Build Verification
+
+### TypeScript Compilation
+
+```bash
+# ビルド時に tsc が実行される（package.json: "build": "tsc -b && vite build"）
+# strict: true により以下を検出:
+# - 未定義の変数・関数
+# - 型の不一致（API レスポンス型の誤り）
+# - null/undefined の未チェック参照
+# - 未使用の変数・import
+```
+
+| Check | Command | Expected | AC |
+|-------|---------|----------|-----|
+| TypeScript compile | `cd frontend && npx tsc --noEmit` | Exit 0, no errors | NFR-Reliability |
+| Vite build | `cd frontend && npm run build` | `src/insight_blueprint/static/` にファイル出力 | FR-23, R6-AC3 |
+| Poe pipeline | `poe build-frontend` | 上記と同じ結果 | R6-AC5 |
+| Build time | `time npm run build` | 30秒以内 | NFR-Performance |
+| Output contents | `ls src/insight_blueprint/static/` | `index.html` + `assets/` (JS/CSS) | FR-23 |
+| Static serving | FastAPI 起動 → `GET /` | `index.html` が返る | R6-AC3 |
+
+### Dev Server Verification
+
+| Check | Command | Expected | AC |
+|-------|---------|----------|-----|
+| Dev start | `cd frontend && npm run dev` | Vite dev server 起動（port 5173） | FR-22, R6-AC1 |
+| HMR | ファイル編集 → ブラウザ自動更新 | 即座に反映 | R6-AC1 |
+| API proxy | Dev server → `GET /api/health` | FastAPI の `{status: "ok"}` が返る | FR-22, R6-AC2 |
+| shadcn/ui | コンポーネント使用 | Tailwind CSS v4 スタイル適用 | FR-21, R6-AC4 |
+
+## Playwright Smoke Tests
+
+### Purpose
+
+手動チェックリスト30項目のうち、リグレッションリスクが高い操作を自動化する。
+CI スイートではなく、**Claude Code + Playwright MCP (`webapp-testing` skill) で実行する開発時検証ツール**。
+
+### Execution
+
+```bash
+# Pre-condition: FastAPI backend running on port 3000
+# Pre-condition: Frontend built (poe build-frontend) or dev server running
+
+# Run all smoke tests
+cd frontend && npx playwright test
+
+# Run via Claude Code (recommended)
+# webapp-testing skill が Playwright MCP 経由でブラウザ操作・スクリーンショット取得を実行
+```
+
+### Test Cases (8 cases)
+
+| # | Test Name | Manual # | Steps | Expected | AC |
+|---|-----------|----------|-------|----------|-----|
+| S1 | Tab routing | #24, #25 | Navigate to each tab, verify URL sync | 4 tabs render, URL updates with ?tab= | R1-AC2, R1-AC3 |
+| S2 | Invalid tab fallback | #26 | Navigate to `?tab=invalid` | Falls back to Designs tab | R1-AC3 |
+| S3 | API error banner | #28 | Load page without backend running | ErrorBanner visible with retry button | R1-AC4 |
+| S4 | Empty state | #30 | Load tabs with no data | EmptyState component visible | R1-AC5 |
+| S5 | Create design dialog | #2 | Click "New Design", fill form, submit | Design appears in list | R2-AC4 |
+| S6 | Status filter | #3 | Select "draft" filter | Only draft designs shown | R2-AC2 |
+| S7 | Design detail expand | #4 | Click design row | Detail panel with sub-tabs visible | R2-AC3 |
+| S8 | Source add with JSON validation | #12, #13 | Add source with invalid JSON | Error shown, valid JSON succeeds | R3-AC3 |
+
+### Configuration
+
+```typescript
+// frontend/playwright.config.ts
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  baseURL: "http://localhost:3000",
+  use: {
+    headless: true,
+  },
+  webServer: {
+    command: "npm run build && cd .. && uvx insight-blueprint --project /tmp/test-project",
+    url: "http://localhost:3000",
+    reuseExistingServer: true,
+  },
+});
+```
+
+### What Playwright Does NOT Cover (→ Manual)
+
+以下は Playwright ではカバーせず、手動チェックリストで検証する:
+
+- Review workflow (Submit for Review, コメント追加): 複数ステップの状態遷移
+- Knowledge extraction/save: 非決定的な出力
+- HMR / dev server: 開発環境固有
+- Browser back/forward (popstate): Playwright の制約
+- Loading spinners: タイミング依存
+
+## Manual Verification Checklist
+
+### Pre-condition
+
+- FastAPI バックエンド起動済み (`uvx insight-blueprint --project /tmp/test-project`)
+- フロントエンドビルド済み (`poe build-frontend`) or dev server 起動済み (`npm run dev`)
+
+### Tab 1: Designs
+
+| # | Operation | Steps | Expected | AC |
+|---|-----------|-------|----------|-----|
+| 1 | 初期表示 | Designs タブを開く | デザイン一覧テーブルが表示される（0件なら EmptyState） | R1-AC1, R2-AC1 |
+| 2 | デザイン作成 | "New Design" → title/hypothesis 入力 → 送信 | ダイアログが閉じ、一覧に新デザインが反映 | R2-AC4, R2-AC5 |
+| 3 | ステータスフィルタ | フィルタで "draft" を選択 | draft のみ表示される | R2-AC2 |
+| 4 | 詳細展開 | デザイン行をクリック | 詳細パネルが展開、Overview サブタブ表示 | R2-AC3 |
+| 5 | Overview 表示 | Overview サブタブ | title, hypothesis, status, metrics 等が表示。dict フィールドは JsonTree | R2-AC3 |
+| 6 | Review 提出 | Review サブタブ → "Submit for Review" | ステータスが pending_review に変更 | R2-AC7 |
+| 7 | Review 無効 | draft のデザインで Review サブタブ | "Submit for Review" ボタンが無効化 | R2-AC11 |
+| 8 | コメント追加 | Review → comment 入力 + status 選択 → 送信 | コメントリストに反映、ステータス更新 | R2-AC8 |
+| 9 | 知識抽出 | Knowledge → "Extract Knowledge" | プレビューリストが表示される | R2-AC9 |
+| 10 | 知識保存 | "Save Knowledge" | 保存確認メッセージ表示 | R2-AC10 |
+
+### Tab 2: Catalog
+
+| # | Operation | Steps | Expected | AC |
+|---|-----------|-------|----------|-----|
+| 11 | 初期表示 | Catalog タブを開く | ソース一覧テーブル（0件なら EmptyState） | R3-AC1 |
+| 12 | ソース追加 | "Add Source" → 情報入力 → 送信 | 一覧に反映 | R3-AC3 |
+| 13 | JSON バリデーション | connection に不正 JSON 入力 | エラーメッセージ表示、送信ブロック | Error Handling #5 |
+| 14 | スキーマ表示 | ソース行をクリック | カラムスキーマテーブルが表示 | R3-AC2 |
+| 15 | カタログ検索 | 検索バーにクエリ入力 → 検索 | マッチ結果が表示される | R3-AC4 |
+| 16 | 知識一覧 | ドメイン知識セクション | エントリが category/importance バッジ付きで表示 | R3-AC5 |
+
+### Tab 3: Rules
+
+| # | Operation | Steps | Expected | AC |
+|---|-----------|-------|----------|-----|
+| 17 | コンテキスト表示 | Rules タブを開く | Sources / Knowledge / Rules の3セクション + カウント | R4-AC1 |
+| 18 | セクション展開 | 各セクションをクリック | 内容が展開/折りたたみ | R4-AC1 |
+| 19 | Cautions 検索 | テーブル名入力 → 検索 | 関連する注意事項が表示される | R4-AC2 |
+| 20 | 空の Cautions | 存在しないテーブル名で検索 | EmptyState 表示 | R4-AC3 |
+
+### Tab 4: History
+
+| # | Operation | Steps | Expected | AC |
+|---|-----------|-------|----------|-----|
+| 21 | タイムライン表示 | History タブを開く | 全デザインが updated_at 降順で表示 | R5-AC1 |
+| 22 | 履歴展開 | エントリをクリック | レビューコメント履歴が展開 | R5-AC2 |
+| 23 | 空の History | デザイン0件 | EmptyState 表示 | R5-AC3 |
+
+### Cross-Tab: Navigation & Error Handling
+
+| # | Operation | Steps | Expected | AC |
+|---|-----------|-------|----------|-----|
+| 24 | タブ切り替え | 各タブをクリック | 即座にコンテンツ切り替え | R1-AC2 |
+| 25 | URL 保持 | `?tab=catalog` で直接アクセス | Catalog タブが初期表示 | R1-AC3 |
+| 26 | 不正 URL | `?tab=invalid` でアクセス | Designs タブにフォールバック | Design: App.tsx |
+| 27 | ブラウザ戻る | タブ切り替え後にブラウザバック | 前のタブに戻る | Design: App.tsx (popstate) |
+| 28 | API エラー | バックエンド停止状態でタブ開く | ErrorBanner + 再試行ボタン | R1-AC4, Error Handling #1 |
+| 29 | ローディング表示 | データ取得中 | スピナー or スケルトン表示 | NFR-Usability |
+| 30 | 空データ | データ0件の各タブ | EmptyState 表示 | R1-AC5 |
+
+## Acceptance Criteria Traceability
+
+### Requirements → Test Mapping
+
+| AC | Test Type | Verification |
+|----|-----------|-------------|
+| R1-AC1 (初期表示) | Playwright S1 + 手動 #1 | 4タブ + Designs 初期表示 |
+| R1-AC2 (タブ切り替え) | **Playwright S1** | 各タブのコンテンツ切り替え |
+| R1-AC3 (?tab= URL) | **Playwright S1, S2** + 手動 #27 | URL パラメータ同期 + popstate |
+| R1-AC4 (API エラー) | **Playwright S3** | ErrorBanner 表示 |
+| R1-AC5 (空データ) | **Playwright S4** | EmptyState 表示 |
+| R2-AC1 (デザイン一覧) | 手動 #1 | テーブル表示 |
+| R2-AC2 (フィルタ) | **Playwright S6** | ステータスフィルタ |
+| R2-AC3 (詳細展開) | **Playwright S7** + 手動 #5 | マスター・ディテール |
+| R2-AC4 (作成) | **Playwright S5** | ダイアログ → API → リスト更新 |
+| R2-AC5 (作成バリデーション) | 手動 #2 | 必須項目チェック |
+| R2-AC6 (Review タブ) | 手動 #6, #8 | コメント一覧 + 操作ボタン |
+| R2-AC7 (Submit Review) | 手動 #6 | ステータス変更 |
+| R2-AC8 (コメント追加) | 手動 #8 | コメントリスト反映 + ステータス更新 |
+| R2-AC9 (Knowledge 抽出) | 手動 #9 | プレビュー表示 |
+| R2-AC10 (Knowledge 保存) | 手動 #10 | 保存確認 |
+| R2-AC11 (非 active 無効化) | 手動 #7 | ボタン無効化 |
+| R3-AC1 (ソース一覧) | 手動 #11 | テーブル表示 |
+| R3-AC2 (スキーマ) | 手動 #14 | カラムテーブル |
+| R3-AC3 (ソース追加) | **Playwright S8** | ダイアログ + JSON バリデーション |
+| R3-AC4 (検索) | 手動 #15 | 検索結果表示 |
+| R3-AC5 (知識一覧) | 手動 #16 | バッジ付きリスト |
+| R4-AC1 (コンテキスト) | 手動 #17, #18 | 3セクション + カウント |
+| R4-AC2 (Cautions) | 手動 #19 | 検索結果 |
+| R4-AC3 (空 Cautions) | 手動 #20 | EmptyState |
+| R5-AC1 (タイムライン) | 手動 #21 | 降順表示 |
+| R5-AC2 (履歴展開) | 手動 #22 | コメント履歴 |
+| R5-AC3 (空 History) | 手動 #23 | EmptyState |
+| R6-AC1 (dev server) | ビルド検証 | `npm run dev` 起動 |
+| R6-AC2 (proxy) | ビルド検証 | `/api/health` proxy |
+| R6-AC3 (build output) | ビルド検証 | `static/` 出力 |
+| R6-AC4 (shadcn/ui) | ビルド検証 + 手動 | スタイル適用 |
+| R6-AC5 (poe pipeline) | ビルド検証 | `poe build-frontend` 成功 |
+
+## Regression Strategy
+
+### SPEC-4a テストへの影響
+
+SPEC-4b は `frontend/` ディレクトリのみを変更し、Python コードは一切変更しない。
+したがって SPEC-4a の 341 テストへのリグレッションリスクはゼロ。
+
+**検証**: SPEC-4b 実装後に `uv run pytest` で全 341 テスト通過を確認する。
+
+### ビルドパイプラインのリグレッション
+
+SPEC-4a で構築した `poe build-frontend` パイプラインとの互換性を維持する:
+- `vite.config.ts` の `outDir` を変更しない
+- `package.json` の `build` スクリプトを変更しない
+- 新規依存の追加は `npm install` で解決可能であること
+
+## Security Considerations
+
+| Concern | Mitigation | Verification |
+|---------|-----------|-------------|
+| XSS | React のデフォルトエスケーピング | `dangerouslySetInnerHTML` の不使用を手動確認 |
+| API injection | フォーム入力のバリデーション + バックエンド側チェック | 手動 #13 (JSON validation) |
+| CORS | SPEC-4a で localhost のみ許可（設定変更なし） | SPEC-4a テスト (`test_cors_*`) |
+| 秘密情報 | フロントエンドに API キー等を含めない | コードレビュー |

--- a/.spec-workflow/specs/inline-review-comments/design.md
+++ b/.spec-workflow/specs/inline-review-comments/design.md
@@ -1,0 +1,368 @@
+# Design: Inline Review Comments
+
+## Overview
+
+Design Detail の Overview タブにインラインコメント機能を統合し、Review タブを廃止する。セクション単位のアンカーとセクション内容のスナップショットを持つコメントを `ReviewBatch` としてバッチ投稿し、AI revision の入力精度を向上させる。
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+
+- **Storage**: YAML primary + atomic write（`tempfile.mkstemp()` + `os.replace()`）。`ReviewBatch` も同パターンに従う
+- **Models**: Pydantic models が single source of truth。`ReviewBatch` / `BatchComment` を `models/review.py` に追加
+- **MCP**: `save_review_batch` ツールを `server.py` に追加。REST API と同一語彙
+- **TDD**: Red-Green-Refactor サイクルでバックエンドのサービス層から実装開始
+
+### Project Structure (structure.md)
+
+- **Layer architecture**: Core Services (`core/reviews.py`) にビジネスロジック追加。`web.py` / `server.py` はトランスポート層のみ
+- **Frontend directory**: SPEC-4b の SRP ディレクトリパターンに従い、`pages/design-detail/components/` にコンポーネント配置
+- **File length**: OverviewPanel は400行以内。超過する機能は専用コンポーネントに分割
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+
+- **`ReviewService`** (`core/reviews.py`): `save_review_batch()` / `list_review_batches()` メソッドを追加
+- **`read_yaml` / `write_yaml`** (`storage/yaml_store.py`): バッチの永続化に atomic write を再利用
+- **`VALID_REVIEW_TRANSITIONS`** (`core/reviews.py`): ステータス遷移バリデーションをバッチ投稿にも適用
+- **`StatusBadge`** (`components/StatusBadge.tsx`): History タブのバッチ表示で再利用
+- **`JsonTree`** (`components/JsonTree.tsx`): OverviewPanel のセクション表示で引き続き使用
+- **`request()`** (`api/client.ts`): 新 API クライアント関数のベース
+- **`ErrorBanner`** (`components/ErrorBanner.tsx`): エラー表示で再利用
+
+### Integration Points
+
+- **`DesignDetail`** (`pages/design-detail/DesignDetail.tsx`): タブ構成変更 + `refreshDesign` コールバック接続
+- **`DesignsPage`** (`pages/DesignsPage.tsx`): `onDesignUpdated` 経由のリスト更新（変更なし）
+
+## Architecture
+
+### 全体構成
+
+```mermaid
+graph TD
+    subgraph Frontend
+        OP[OverviewPanel] --> SR[SectionRenderer]
+        SR --> ICA[InlineCommentAnchor]
+        ICA --> DCF[DraftCommentForm]
+        OP --> RBC[ReviewBatchComposer]
+        OP --> UDR[useReviewDrafts hook]
+        RHP[ReviewHistoryPanel] --> BatchCard
+    end
+    subgraph API
+        POST_BATCH[POST /review-batches]
+        GET_BATCH[GET /review-batches]
+    end
+    subgraph Backend
+        RS[ReviewService] --> YS[YamlStore]
+        RS --> DS[DesignService]
+    end
+    RBC -->|submit| POST_BATCH
+    RHP -->|fetch| GET_BATCH
+    POST_BATCH --> RS
+    GET_BATCH --> RS
+```
+
+### Modular Design Principles
+
+- **Single File Responsibility**: `SectionRenderer`（表示）/ `InlineCommentAnchor`（アンカーUI）/ `DraftCommentForm`（入力）/ `ReviewBatchComposer`（投稿）を分離
+- **Component Isolation**: 各セクションのコメント状態は `useReviewDrafts` hook でセクション単位に購読し、無関係なセクションの再レンダリングを防ぐ
+- **Service Layer Separation**: `ReviewService` がバッチ保存を担う。`web.py` / `server.py` はデータ変換のみ
+- **Section Registry Pattern**: コメント対象セクションをハードコードせず、registry 定義で管理する（セクション追加時の変更漏れ防止）
+
+```typescript
+// Section registry — single source of truth for commentable sections
+const COMMENTABLE_SECTIONS = [
+  { id: "hypothesis_statement", label: "Hypothesis Statement", type: "text" },
+  { id: "hypothesis_background", label: "Hypothesis Background", type: "text" },
+  { id: "metrics", label: "Metrics", type: "json" },
+  { id: "explanatory", label: "Explanatory", type: "json" },
+  { id: "chart", label: "Chart", type: "json" },
+  { id: "next_action", label: "Next Action", type: "json" },
+] as const;
+```
+
+## Components and Interfaces
+
+### Backend: `ReviewBatch` / `BatchComment` モデル
+
+- **Purpose**: バッチ単位のレビューコメントを表現する Pydantic モデル
+- **Interfaces**:
+  ```python
+  # JSON 互換の再帰型（YAML シリアライズ安全）
+  JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+
+  class BatchComment(BaseModel, extra="forbid"):
+      comment: str
+      target_section: str | None = None
+      target_content: JsonValue = None  # セクション内容のスナップショット（レビュー時点）
+
+      @model_validator(mode="after")
+      def target_content_requires_section(self) -> Self:
+          if self.target_section and self.target_content is None:
+              raise ValueError("target_content is required when target_section is set")
+          return self
+
+  class ReviewBatch(BaseModel, extra="forbid"):
+      id: str                          # "RB-{uuid4.hex[:8]}"
+      design_id: str
+      status_after: DesignStatus
+      reviewer: str = "analyst"
+      comments: list[BatchComment]     # 1件以上
+      created_at: datetime = Field(default_factory=now_jst)
+  ```
+- **Dependencies**: `models.design.DesignStatus`, `models.common.now_jst`
+- **Reuses**: 既存の `ReviewComment` と同じモジュールに配置
+- **Validation rules**:
+  - `target_section` が設定されている場合、`target_content` は必須
+  - `extra="forbid"` で想定外フィールドの混入を防止
+
+### Backend: `ReviewService` 拡張
+
+- **Purpose**: バッチ保存・取得のビジネスロジック
+- **Interfaces**:
+  ```python
+  def save_review_batch(
+      self, design_id: str, status: str,
+      comments: list[dict], reviewer: str = "analyst",
+  ) -> ReviewBatch | None
+
+  def list_review_batches(self, design_id: str) -> list[ReviewBatch]
+  # 返却順: created_at 降順（新しい順）
+  ```
+- **Dependencies**: `DesignService`, `YamlStore`
+- **Reuses**: `VALID_REVIEW_TRANSITIONS`, `_validate_id`, `read_yaml` / `write_yaml`
+- **Atomicity**: `save_review_batch` の操作順序:
+  1. YAML に ReviewBatch を書き込む（atomic write）
+  2. 書き込み成功後、Design のステータスを遷移する
+  3. ステータス遷移が失敗した場合、バッチは保存済みだがステータスは未遷移。ユーザーに再試行を促す（ローカルツールのため発生確率は極めて低い）
+
+### Backend: REST API エンドポイント
+
+- **Purpose**: ReviewBatch の投稿・取得エンドポイント
+- **Interfaces**:
+  ```python
+  @app.post("/api/designs/{design_id}/review-batches")
+  async def submit_review_batch(design_id, body: SubmitBatchRequest) -> dict
+  # body: { status_after, reviewer?, comments: [{comment, target_section?, target_content?}] }
+  # response: { batch_id, status_after, comment_count }
+
+  @app.get("/api/designs/{design_id}/review-batches")
+  async def list_review_batches(design_id) -> dict
+  # response: { design_id, batches: ReviewBatch[], count }
+  ```
+- **Dependencies**: `ReviewService`
+- **Reuses**: 既存の `_ID_PATTERN`, `ApiError`
+
+### Frontend: `useReviewDrafts` hook
+
+- **Purpose**: ドラフトコメントの状態管理。React state のみ（揮発性）。`beforeunload` 警告を含む
+- **Interfaces**:
+  ```typescript
+  function useReviewDrafts(designId: string): {
+    drafts: DraftComment[];
+    addDraft: (section: string, comment: string, content: unknown) => void;
+    removeDraft: (draftId: string) => void;
+    clearAll: () => void;
+    hasDrafts: boolean;
+    draftsBySection: Map<string, DraftComment[]>;
+  }
+  ```
+- **Dependencies**: React (`useState`, `useEffect`, `useCallback`)
+- **Reuses**: なし（新規）
+
+### Frontend: `SectionRenderer`
+
+- **Purpose**: Design の1セクションを表示する。セクション種別（text / json）に応じてレンダリングを切り替え
+- **Interfaces**:
+  ```typescript
+  interface SectionRendererProps {
+    section: CommentableSection;  // registry のエントリ
+    value: unknown;               // Design の該当フィールドの値
+    isReviewMode: boolean;        // pending_review かどうか
+    drafts: DraftComment[];       // このセクションのドラフト
+    onAddDraft: (comment: string) => void;
+    onRemoveDraft: (draftId: string) => void;
+  }
+  ```
+- **Dependencies**: `JsonTree`, `InlineCommentAnchor`, `DraftCommentForm`
+- **Reuses**: `JsonTree`, `Field` helper
+- **Note**: `onAddDraft` 呼び出し時、`SectionRenderer` が `structuredClone(value)`（現在のセクション内容の deep copy）を `target_content` として hook に渡す。後続の Design 編集でスナップショットが変わらないことを保証する
+
+### Frontend: `InlineCommentAnchor`
+
+- **Purpose**: セクション横のコメントボタン。クリックで `DraftCommentForm` をトグル
+- **Interfaces**: `{ onAdd: (comment: string) => void; isReviewMode: boolean }`
+- **Dependencies**: shadcn/ui `Button`
+- **Reuses**: なし
+
+### Frontend: `DraftCommentForm`
+
+- **Purpose**: インラインのテキスト入力フォーム。送信でドラフトに追加
+- **Interfaces**: `{ onSubmit: (comment: string) => void; onCancel: () => void }`
+- **Dependencies**: shadcn/ui `Textarea`, `Button`
+- **Reuses**: なし
+
+### Frontend: `ReviewBatchComposer`
+
+- **Purpose**: 画面下部のフローティングバー。ドラフト件数 + ステータスセレクタ + Submit All
+- **Interfaces**:
+  ```typescript
+  interface ReviewBatchComposerProps {
+    designId: string;
+    drafts: DraftComment[];
+    onSubmitted: () => void;  // 送信成功後のコールバック
+    onClearDrafts: () => void;
+  }
+  ```
+- **Dependencies**: `submitReviewBatch` API client, shadcn/ui `Select`, `Button`
+- **Reuses**: `COMMENT_STATUSES` 定数（旧 ReviewPanel から移動）
+- **Note**: Submit ボタンは送信中 `disabled` にする（UI レベルの二重投稿防止）
+
+### Frontend: `ReviewHistoryPanel`
+
+- **Purpose**: 旧 ReviewPanel のリネーム。過去の ReviewBatch を read-only 表示。各コメントに `target_content`（レビュー時点のセクション内容）を引用表示する
+- **Interfaces**: `{ designId: string }`
+- **Dependencies**: `listReviewBatches` API client, `StatusBadge`, `JsonTree`
+- **Reuses**: `StatusBadge`, `formatDateTime`
+
+## Data Models
+
+### ReviewBatch (backend, new)
+
+```python
+JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+
+class BatchComment(BaseModel, extra="forbid"):
+    comment: str                        # コメントテキスト（max 2000 chars）
+    target_section: str | None = None   # "hypothesis_statement" | "metrics" | ...
+    target_content: JsonValue = None    # レビュー時点のセクション内容スナップショット
+    # Validation: target_section が set なら target_content 必須
+
+class ReviewBatch(BaseModel, extra="forbid"):
+    id: str                            # "RB-{uuid4.hex[:8]}"
+    design_id: str
+    status_after: DesignStatus         # バッチ全体で1つのステータス遷移
+    reviewer: str = "analyst"
+    comments: list[BatchComment]       # 1件以上
+    created_at: datetime
+```
+
+### YAML Storage Schema
+
+```yaml
+# {design_id}_reviews.yaml
+batches:
+  - id: "RB-a1b2c3d4"
+    design_id: "DES-xyz"
+    status_after: "active"
+    reviewer: "analyst"
+    comments:
+      - comment: "仮説の指標が曖昧"
+        target_section: "hypothesis_statement"
+        target_content: "〇〇の施策はCVRを改善する"
+      - comment: "KPI測定期間が未定義"
+        target_section: "metrics"
+        target_content:
+          kpi_name: "CVR"
+          current_value: "2.5%"
+          target_value: null
+    created_at: "2026-03-01T10:00:00+09:00"
+```
+
+`batches` キーがないファイル、またはファイル自体が存在しない場合は空リストとして扱う。旧形式（`comments` キーのみ）のデータは無視し、warning ログを出力する。
+
+### Section Definition Sync
+
+バックエンドの `ALLOWED_TARGET_SECTIONS`（`core/reviews.py`）とフロントエンドの `COMMENTABLE_SECTIONS` は同一のセクション ID リストを保持する必要がある。バックエンドが正（バリデーション責務）、フロントエンドが従（UI 表示責務）。セクション追加時は両方を更新する。
+
+### Frontend Types (new)
+
+```typescript
+interface BatchComment {
+  comment: string;
+  target_section: string | null;
+  target_content: JsonValue;  // text sections: string, json sections: object
+}
+
+// JSON-compatible recursive type
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+interface ReviewBatch {
+  id: string;
+  design_id: string;
+  status_after: DesignStatus;
+  reviewer: string;
+  comments: BatchComment[];
+  created_at: string;
+}
+
+interface DraftComment {
+  id: string;             // crypto.randomUUID()
+  target_section: string;
+  target_content: JsonValue;  // structuredClone でキャプチャしたスナップショット
+  comment: string;
+}
+
+interface SubmitBatchRequest {
+  status_after: DesignStatus;
+  reviewer?: string;
+  comments: { comment: string; target_section?: string; target_content?: JsonValue }[];
+}
+```
+
+## Error Handling
+
+### Error Scenarios
+
+1. **バッチ投稿時に Design が `pending_review` でない**
+   - **Handling**: API が 400 エラーを返す。`ReviewService.save_review_batch()` で事前チェック
+   - **User Impact**: Submit Bar にエラーメッセージ表示。ドラフトは保持される
+
+2. **YAML atomic write 失敗**
+   - **Handling**: `write_yaml()` の例外をキャッチ。ステータス遷移は行わない（NFR-8 準拠）
+   - **User Impact**: エラーメッセージ表示。再試行可能
+
+3. **`target_section` に不正な値**
+   - **Handling**: `ALLOWED_TARGET_SECTIONS` リストに対してバリデーション。不一致は 422 エラー（レスポンスに不正フィールド名を含む）
+   - **User Impact**: フロントエンドが registry からのみ `target_section` を生成するため、正常利用では発生しない
+
+4. **ドラフト未送信でページ離脱**
+   - **Handling**: `beforeunload` イベントで確認ダイアログ表示
+   - **User Impact**: 意図しない離脱を警告。ドラフトは揮発性のため離脱すると消失する
+
+5. **存在しない `design_id`**
+   - **Handling**: `DesignService` が design を見つけられず `None` 返却 → API が 404 を返す
+   - **User Impact**: エラーメッセージ表示
+
+6. **コメントバリデーション違反（空コメント、2000文字超過、空配列）**
+   - **Handling**: Pydantic バリデーションで 422 を返す。レスポンスに違反フィールド情報を含む
+   - **User Impact**: Submit Bar にバリデーションエラー表示。ドラフトは保持される
+
+7. **YAML ファイル破損（GET 時のパースエラー）**
+   - **Handling**: `read_yaml()` がパース失敗 → warning ログ出力 + 空リスト返却
+   - **User Impact**: 過去のバッチが表示されないが、新規投稿は可能
+
+## Testing Strategy
+
+### Unit Testing
+
+- **`ReviewService.save_review_batch()`**: 正常系（バッチ保存 + ステータス遷移）、異常系（非 `pending_review`、不正ステータス、空コメント）
+- **`ReviewService.list_review_batches()`**: バッチ取得、空リスト、降順ソート
+- **`target_section` validation**: 有効値の通過、不正値の拒否
+- **`target_content` preservation**: テキスト型・JSON 型の両方が保存・復元されること
+- **YAML write failure**: 書き込み失敗時にステータスが遷移しないこと
+
+### Integration Testing
+
+- **REST API** (`TestClient`):
+  - `POST /review-batches` → バッチ保存 → `GET /review-batches` で取得確認
+  - ステータス遷移の連動確認（`pending_review` → `status_after`）
+  - `target_content` の round-trip 確認
+- **MCP tool**: `save_review_batch` ツールの正常系・異常系
+
+### End-to-End Testing
+
+- フルレビューフロー: Design 作成 → `active` → `pending_review` → ドラフト追加 → バッチ投稿 → ステータス遷移確認
+- History タブ: 複数バッチの時系列表示 + `target_content` の引用表示確認

--- a/.spec-workflow/specs/inline-review-comments/requirements.md
+++ b/.spec-workflow/specs/inline-review-comments/requirements.md
@@ -1,0 +1,127 @@
+# Requirements: Inline Review Comments
+
+## Introduction
+
+現在の Review ワークフローには2つの問題がある。Overview タブと Review タブが分離しておりコンテキスト断絶が起きる。コメントに Design セクションへのアンカーがなく指摘対象が不明。本機能はセクション単位のインラインコメントとバッチ投稿を導入し、レビュワーの UX と AI revision の精度を同時に改善する。
+
+## Alignment with Product Vision
+
+1. **ドメイン知識の蓄積品質向上**: アンカー付きコメントにより、knowledge extraction の精度が上がる（product.md: "analyst review comments からの domain knowledge 蓄積"）
+2. **AI-driven analysis workflow**: `target_section` + `target_content` により AI revision が指摘対象セクションの元内容を参照しピンポイントで修正可能（product.md: "AI-driven exploratory data analysis"）
+3. **軽量レビュー**: タブ往復の排除とバッチ投稿で、hypothesis-driven な軽量ワークフローを維持（product.md: "lightweight, hypothesis-driven analysis design docs"）
+
+## Requirements
+
+### 1. Inline Contextual Comments
+
+**User Story:** データアナリストとして、レビュー対象のセクション横にコメントを直接追加したい。タブ切り替えでコンテキストを失わないために。
+
+- FR-1: Design の各コメント対象セクション（`hypothesis_statement`, `hypothesis_background`, `metrics`, `explanatory`, `chart`, `next_action`）の横にコメントボタンを表示する
+- FR-2: コメントボタンは `pending_review` 時のみ表示する
+- FR-3: コメントボタンクリックで、該当セクション下にインラインコメントフォームを展開する
+- FR-4: 各コメントに `target_section` フィールドを持たせ、対象セクションを識別する
+
+#### Acceptance Criteria
+
+1. WHEN Design の status が `pending_review` THEN Overview パネルの6セクション横にコメントボタンを表示する
+2. WHEN status が `pending_review` 以外 THEN コメントボタンを非表示にする
+3. WHEN コメントボタンをクリック THEN 該当セクション下にテキスト入力フォームを展開する
+4. WHEN インラインコメントを追加 THEN `target_section` にセクション識別子（例: `"hypothesis_statement"`）を設定してドラフト保存する
+
+### 2. Draft Management and Batch Submission
+
+**User Story:** データアナリストとして、複数のコメントをドラフトとして溜めてから一括で投稿したい。Design 全体を確認してからレビュー判定を下すために。
+
+- FR-5: 複数のドラフトコメントをクライアント state に蓄積できる
+- FR-6: ドラフトが1件以上あるとき、フローティングの Review Submit Bar を表示する（ドラフト件数 + ステータスセレクタ + "Submit All" ボタン）
+- FR-7: ステータスセレクタの選択肢: `supported`, `rejected`, `inconclusive`, `active`（request changes）
+- FR-8: "Submit All" で全ドラフトを1つの `ReviewBatch` として POST し、ステータス遷移は1回だけ
+- FR-9: 投稿成功後、ドラフトをクリアし Design を再取得する
+
+#### Acceptance Criteria
+
+1. WHEN ドラフトを追加 THEN Review Submit Bar にドラフト件数を更新表示する
+2. WHEN ドラフトを削除し残り0件 THEN Submit Bar を非表示にする
+3. WHEN "Submit All" をクリック THEN `POST /api/designs/{id}/review-batches` に全ドラフトを1バッチで送信する
+4. WHEN バッチ投稿成功 THEN `status_after` の値に1回だけステータス遷移する
+5. WHEN バッチ投稿成功 THEN ドラフトをクリアし Design データを refresh する
+
+### 3. ReviewBatch Data Model
+
+**User Story:** システムメンテナーとして、レビューコメントをバッチ単位でグループ化し、1バッチ=1ステータス遷移としたい。データモデルがレビューワークフローを正確に表現するために。
+
+- FR-10: `ReviewBatch` モデルを導入する（`id`, `design_id`, `status_after`, `reviewer`, `comments: list[BatchComment]`, `created_at`）
+- FR-11: `BatchComment` は `comment`（テキスト）、`target_section`（optional string）、`target_content`（対象セクションのレビュー時点のスナップショット）を持つ
+- FR-12: `POST /api/designs/{id}/review-batches` でバッチ投稿を受け付ける
+- FR-13: `GET /api/designs/{id}/review-batches` で全バッチを取得する
+- FR-14: `{design_id}_reviews.yaml` の `batches` キーにバッチを永続化する
+
+#### Acceptance Criteria
+
+1. WHEN 有効な ReviewBatch を POST THEN YAML に永続化し Design のステータスを遷移する
+2. WHEN status が `pending_review` でない THEN バッチ投稿 API は 400 エラーを返す
+3. WHEN GET review-batches THEN 全バッチを `created_at` 降順で返す
+4. WHEN ReviewBatch を永続化 THEN 各コメントの `target_section` と `target_content` を保持する
+
+### 4. Tab Restructuring
+
+**User Story:** データアナリストとして、Design の内容表示とコメント投稿を1つの画面で行いたい。タブ切り替えなしでレビューを完結するために。
+
+- FR-15: `DesignDetail` のタブ構成を `Overview | Review | Knowledge` から `Overview | History | Knowledge` に変更する
+- FR-16: Overview タブにインラインコメント機能を統合する（旧 Review タブの機能を吸収）
+- FR-17: History タブに過去の ReviewBatch を read-only リスト形式で表示する。各コメントに `target_content`（レビュー時点のセクション内容）を並べて表示する
+
+#### Acceptance Criteria
+
+1. WHEN Design 詳細を開く THEN タブは "Overview", "History", "Knowledge" の3つ
+2. WHEN `pending_review` の Design で Overview タブにいる THEN タブ切り替えなしでインラインコメントが可能
+3. WHEN History タブに切り替え THEN 過去の ReviewBatch がコメント・`target_section`・`target_content`・タイムスタンプ付きで表示される
+
+### 5. MCP Tool Update
+
+**User Story:** MCP ツールを使う AI エージェントとして、セクションアンカー付きのレビューバッチを投稿したい。構造化されたレビューフィードバックを提供するために。
+
+- FR-18: `save_review_batch` MCP ツールを追加する（`target_section` + `target_content` 付きコメントリスト + 単一 `status_after`）
+
+#### Acceptance Criteria
+
+1. WHEN MCP クライアントが `save_review_batch` を呼び出す THEN ReviewBatch を作成しステータスを遷移する
+
+## Non-Functional Requirements
+
+### Code Architecture and Modularity
+
+- **NFR-1**: `ReviewBatch`, `BatchComment` は `models/review.py` に定義する（Pydantic models の single-source-of-truth パターン維持、structure.md 準拠）
+- **NFR-2**: バッチレビューのビジネスロジックは `core/reviews.py`（ReviewService）に追加する
+- **NFR-3**: 新規フロントエンドコンポーネント（`SectionRenderer`, `DraftCommentForm`, `ReviewBatchComposer`）は `pages/design-detail/components/` に配置する（SPEC-4b の SRP ディレクトリパターン準拠）
+- **NFR-4**: リファクタ後の OverviewPanel は400行以内に収める。インラインコメント機能は専用コンポーネントに切り出す
+
+### Performance
+
+- **NFR-5**: ドラフト state の更新で無関係なセクションの re-render を起こさない
+
+### Security
+
+- **NFR-6**: コメントテキストは XSS 防止のためレンダリング前にサニタイズする
+- **NFR-7**: `target_section` は既知のセクション識別子に対してバリデーションする
+
+### Reliability
+
+- **NFR-8**: バッチ投稿は YAML-first atomicity — YAML への永続化は atomic write で保証する。ステータス遷移は YAML 書き込み成功後に実行する。YAML 書き込み失敗時はステータスも遷移しない。YAML 成功後にステータス遷移が失敗した場合、バッチは保存済みだがステータスは未遷移となる（ローカルツールのため発生確率は極めて低い。再試行で回復可能）
+- **NFR-9**: （NFR-8 に統合）
+
+### Usability
+
+- **NFR-10**: ドラフトコメントは投稿済みコメントと視覚的に区別する（破線ボーダー、"draft" ラベル等）
+- **NFR-11**: ドラフトが存在するとき、Review Submit Bar はスクロールなしで常に見える（sticky/fixed）
+- **NFR-12**: ドラフト削除はワンクリック（確認ダイアログなし — ドラフトは揮発性データ）
+
+## Out of Scope
+
+- **フィールドレベルアンカー**（例: `metrics.kpi_name`）: セクション単位で十分。将来 `target_section` をドット記法に拡張可能
+- **サーバーサイドドラフト永続化**: 単一ユーザーツールのため、クライアント React state のみ
+- **AI revision API 実装**: 本 spec はアンカーデータ + スナップショットの提供まで。revision エンドポイントは別機能
+- **リアルタイムコラボレーション**: 同時レビュワー同期（WebSocket）は不要。単一ユーザー前提
+- **投稿済みバッチの編集・削除**: 投稿済みバッチは immutable
+- **レガシーデータの後方互換・マイグレーション**: 旧 `comments` 形式のデータは移行しない。新形式 `batches` で上書き
+- **重複投稿防止（idempotency key）**: Submit ボタンの disable で UI レベルで防止。サーバーサイドの冪等性は不要

--- a/.spec-workflow/specs/inline-review-comments/tasks.md
+++ b/.spec-workflow/specs/inline-review-comments/tasks.md
@@ -1,0 +1,319 @@
+# Tasks: Inline Review Comments
+
+## Notes
+
+- **TDD 順序**: 各フェーズでテストを先に書き（RED）、実装で通す（GREEN）。タスク番号の小さい方が先
+- **NFR-8 原子性**: design.md の仕様に従う — YAML 書き込み成功後にステータス遷移。ステータス遷移失敗時はバッチ保存済み・ステータス未遷移（要再試行）。requirements.md の "all-or-nothing" 表現はローカルツールの現実的制約を反映して design.md で refinement 済み
+- **NFR-6 XSS**: React の JSX は default でエスケープするため、全コンポーネントで `dangerouslySetInnerHTML` の使用を禁止する。これにより NFR-6 を満たす
+
+---
+
+## Phase 1: Models (test-design P1)
+
+- [x] 1. Write unit tests for `BatchComment` and `ReviewBatch` models (RED)
+  - File: `tests/test_review_models.py` (modify)
+  - Add `TestBatchComment` class: valid construction, optional target_section, target_content_requires_section (model_validator), text/json target_content preservation, non-JSON value rejection (parametrize: datetime, set), empty/whitespace comment rejection, max length boundary (2000/2001), empty string target_section rejection, extra field rejection
+  - Add `TestReviewBatch` class: valid construction, id format (RB- prefix + 8 hex), invalid status rejection, empty comments rejection, JST default timestamp, reviewer default, JSON round-trip, extra field rejection
+  - Purpose: TDD Red phase — model contracts を先に定義する
+  - _Leverage: `tests/test_review_models.py` (existing class-based pattern), `tests/conftest.py` (fixtures)_
+  - _Requirements: FR-10, FR-11_
+  - _Prompt: Role: Python test engineer | Task: Write comprehensive unit tests for BatchComment and ReviewBatch models covering all P1 test cases from test-design.md | Restrictions: Follow existing class-based grouping pattern, use parametrize for multi-value tests, add AC reference docstrings. Tests will initially fail (RED phase) | Success: Tests correctly define the expected model behavior — will pass after Task 1.1_
+  - **完了基準**: `TestBatchComment` と `TestReviewBatch` が test-design.md P1 の全ケースを網羅している
+  - **確認手順**: `uv run pytest tests/test_review_models.py -v --co -k "TestBatchComment or TestReviewBatch"` でテストケースが収集される（RED 状態で OK）
+
+- [x] 1.1 Implement `BatchComment` and `ReviewBatch` Pydantic models (GREEN)
+  - File: `src/insight_blueprint/models/review.py` (modify), `src/insight_blueprint/models/__init__.py` (modify)
+  - Define `JsonValue` recursive type alias for YAML-safe serializable values
+  - Add `BatchComment(BaseModel, extra="forbid")` with `comment`, `target_section`, `target_content: JsonValue`, and `model_validator` ensuring `target_section` set implies `target_content` required
+  - Add `ReviewBatch(BaseModel, extra="forbid")` with `id`, `design_id`, `status_after`, `reviewer`, `comments: list[BatchComment]`, `created_at`
+  - Add `comment` field validation: non-empty, strip whitespace, max 2000 chars
+  - Add `target_section` validation: must be `None` or non-empty string (empty string rejected)
+  - Re-export new models from `__init__.py`
+  - Purpose: Task 1 のテストを GREEN にする
+  - _Leverage: `models/review.py` (existing `ReviewComment`), `models/common.py` (`now_jst`), `models/design.py` (`DesignStatus`)_
+  - _Requirements: FR-10, FR-11, NFR-1_
+  - _Prompt: Role: Python developer with Pydantic expertise | Task: Create `BatchComment` and `ReviewBatch` models with `JsonValue` type alias, `model_validator`, `extra="forbid"`, and field-level validations per FR-10/FR-11 | Restrictions: Do not modify existing `ReviewComment`. Keep `JsonValue` as a module-level type alias. Use `model_validator(mode="after")` not `field_validator` | Success: All Task 1 tests pass green_
+  - **完了基準**: Task 1 の全テストが GREEN になる
+  - **確認手順**: `uv run pytest tests/test_review_models.py -v -k "TestBatchComment or TestReviewBatch"` で全テストがパスする。`uv run ruff check src/insight_blueprint/models/review.py` がパスする
+
+## Phase 2: Service Layer (test-design P2 + P3)
+
+- [x] 2. Write unit tests for `ReviewService` batch methods (RED)
+  - File: `tests/test_reviews.py` (modify), `tests/conftest.py` (modify)
+  - Add fixtures to `conftest.py`: `review_batch_data`, `make_batch_payload` (factory), `non_pending_design`, `fixed_now` (dual-patch for `models.common` + `models.review`), `corrupted_reviews_yaml`, `status_update_failure`
+  - Add `TestSaveReviewBatch` class: valid save, status transition, YAML persistence, target_section preservation, target_content text/json, non-pending rejection, invalid status, empty comments, invalid design_id (parametrize), missing design, YAML write failure (no status change), status update failure (batch preserved — atomicity order), all 4 status transitions (parametrize), append to existing, create new file
+  - Add `TestSaveReviewBatchTargetSectionValidation` class: valid sections (parametrize 6), invalid section, null section accepted
+  - Add `TestListReviewBatches` class: returns all, descending order, empty, nonexistent design, no file, no batches key (+ warning log), target_content preservation, corrupted YAML (+ warning log)
+  - Purpose: TDD Red phase — service contracts を先に定義する。P2 + P3 全ケース
+  - _Leverage: `tests/test_reviews.py` (existing patterns), `tests/conftest.py` (existing fixtures)_
+  - _Requirements: FR-4, FR-7, FR-8, FR-11, FR-12, FR-13, FR-14, NFR-7, NFR-8, NFR-9_
+  - _Prompt: Role: Python test engineer | Task: Write unit tests for save_review_batch and list_review_batches covering all P2+P3 test cases from test-design.md | Restrictions: Follow existing class-based pattern, use `fixed_now` for timestamp tests, mock YAML write for failure tests. Tests will initially fail (RED phase) | Success: Tests correctly define expected service behavior — will pass after Tasks 2.1 and 2.2_
+  - **完了基準**: test-design.md P2 + P3 の全テストケースが定義されている
+  - **確認手順**: `uv run pytest tests/test_reviews.py -v --co -k "SaveReviewBatch or ListReviewBatches or TargetSectionValidation"` でテストケースが収集される
+
+- [x] 2.1 Implement `save_review_batch` in `ReviewService` (GREEN)
+  - File: `src/insight_blueprint/core/reviews.py` (modify)
+  - Add `ALLOWED_TARGET_SECTIONS` set: `{"hypothesis_statement", "hypothesis_background", "metrics", "explanatory", "chart", "next_action"}`
+  - Implement `save_review_batch(design_id, status, comments, reviewer)` method:
+    - Validate design_id, check design exists and is `pending_review`
+    - Validate `status` against `VALID_REVIEW_TRANSITIONS`
+    - Validate each comment's `target_section` against `ALLOWED_TARGET_SECTIONS`
+    - Create `ReviewBatch` with `RB-{uuid4.hex[:8]}` id
+    - Write batch to `{design_id}_reviews.yaml` under `batches` key (atomic write via `write_yaml`)
+    - On YAML success, transition design status
+    - Return `ReviewBatch` or `None`
+  - Purpose: Task 2 の `TestSaveReviewBatch` + `TestSaveReviewBatchTargetSectionValidation` を GREEN にする
+  - _Leverage: `save_review_comment()` (existing pattern), `VALID_REVIEW_TRANSITIONS`, `_validate_id()`, `read_yaml`/`write_yaml`_
+  - _Requirements: FR-8, FR-12, FR-14, NFR-2, NFR-7, NFR-8, NFR-9_
+  - _Prompt: Role: Python backend developer | Task: Implement `save_review_batch` in ReviewService with YAML atomic write, status transition, and target_section validation | Restrictions: Follow existing method patterns. YAML write first, then status update (atomicity order). Do not modify existing `save_review_comment` | Success: Task 2 の save 関連テストが全て GREEN_
+  - **完了基準**: `TestSaveReviewBatch` と `TestSaveReviewBatchTargetSectionValidation` の全テストが GREEN
+  - **確認手順**: `uv run pytest tests/test_reviews.py -v -k "SaveReviewBatch or TargetSectionValidation"` で全テストがパスする
+
+- [x] 2.2 Implement `list_review_batches` in `ReviewService` (GREEN)
+  - File: `src/insight_blueprint/core/reviews.py` (modify)
+  - Implement `list_review_batches(design_id)` method:
+    - Read `{design_id}_reviews.yaml`, extract `batches` key
+    - If file not found or `batches` key missing → return empty list (+ `logging.warning()`)
+    - If YAML parse error → `logging.warning()` + return empty list
+    - If old format (`comments` key without `batches`) → `logging.warning()` + return empty list
+    - Sort by `created_at` descending
+    - Return `list[ReviewBatch]`
+  - Purpose: Task 2 の `TestListReviewBatches` を GREEN にする
+  - _Leverage: `list_comments()` (existing read pattern), `read_yaml()`_
+  - _Requirements: FR-13_
+  - _Prompt: Role: Python backend developer | Task: Implement `list_review_batches` with YAML corruption handling and warning logs | Restrictions: Do not raise exceptions on corrupt/missing data — return empty list. Use `logging.warning()` for degraded states | Success: Task 2 の list 関連テストが全て GREEN_
+  - **完了基準**: `TestListReviewBatches` の全テストが GREEN
+  - **確認手順**: `uv run pytest tests/test_reviews.py -v -k "ListReviewBatches"` で全テストがパスする。`uv run ruff check src/insight_blueprint/core/reviews.py` がパスする
+
+## Phase 3: Transport Layer (test-design P5 + P6)
+
+- [x] 3. Write integration tests for REST API and MCP tool (RED)
+  - File: `tests/test_web.py` (modify), `tests/test_server.py` (modify)
+  - Add `TestReviewBatchAPI` class to `test_web.py`: submit success (201), status transition, all 4 statuses (parametrize), non-pending 400, invalid design 404, invalid section 422, empty comments 422, overlength comment 422, missing target_content 422, extra field 422, with target_content round-trip, list success, list empty, list descending, list includes target_content
+  - Add `TestSaveReviewBatchTool` class to `test_server.py`: success, with sections, non-pending error
+  - Purpose: TDD Red phase — transport contracts を先に定義する。P5 + P6 全ケース
+  - _Leverage: `tests/test_web.py` (existing `client` fixture, `_create_pending_design_via_api` helper), `tests/test_server.py` (existing `initialized_review_server` fixture)_
+  - _Requirements: FR-7, FR-8, FR-12, FR-13, FR-18, NFR-7_
+  - _Prompt: Role: Python integration test engineer | Task: Write integration tests for review-batch REST API and MCP tool covering P5+P6 test cases from test-design.md | Restrictions: Use existing test fixtures and helpers. Follow existing test patterns. Tests will initially fail (RED phase) | Success: Tests correctly define expected transport behavior_
+  - **完了基準**: test-design.md P5 + P6 の全テストケースが定義されている
+  - **確認手順**: `uv run pytest tests/test_web.py::TestReviewBatchAPI tests/test_server.py::TestSaveReviewBatchTool -v --co` でテストケースが収集される
+
+- [x] 3.1 Implement REST API endpoints for review batches (GREEN)
+  - File: `src/insight_blueprint/web.py` (modify)
+  - Add `SubmitBatchRequest` Pydantic model: `status_after: str`, `reviewer: str = "analyst"`, `comments: list[dict]`
+  - Add `POST /api/designs/{design_id}/review-batches` endpoint:
+    - Call `review_service.save_review_batch()`
+    - Return 201 with `{batch_id, status_after, comment_count}`
+    - Handle ValueError → 400, ValidationError → 422, None → 404
+  - Add `GET /api/designs/{design_id}/review-batches` endpoint:
+    - Call `review_service.list_review_batches()`
+    - Return `{design_id, batches: [...], count}`
+  - Purpose: Task 3 の `TestReviewBatchAPI` を GREEN にする
+  - _Leverage: `web.py` (existing endpoint patterns, `_ID_PATTERN`, `ApiError`), `submit_review`/`add_comment` handlers_
+  - _Requirements: FR-12, FR-13_
+  - _Prompt: Role: Python web developer (Starlette/FastAPI) | Task: Add POST/GET /review-batches endpoints following existing handler patterns | Restrictions: Follow existing error handling (ValueError→400, ValidationError→422). Do not duplicate business logic from ReviewService | Success: Task 3 の REST API テストが全て GREEN_
+  - **完了基準**: `TestReviewBatchAPI` の全テストが GREEN
+  - **確認手順**: `uv run pytest tests/test_web.py::TestReviewBatchAPI -v` で全テストがパスする
+
+- [x] 3.2 Implement `save_review_batch` MCP tool (GREEN)
+  - File: `src/insight_blueprint/server.py` (modify)
+  - Add `save_review_batch` MCP tool with parameters: `design_id`, `status_after`, `comments` (list of dicts with `comment`, `target_section`, `target_content`), `reviewer`
+  - Call `review_service.save_review_batch()` internally
+  - Return success dict with batch_id and status_after, or error dict
+  - Purpose: Task 3 の `TestSaveReviewBatchTool` を GREEN にする
+  - _Leverage: `server.py` (existing tool patterns: `save_review_comment` tool), `_validate_design_id()`_
+  - _Requirements: FR-18_
+  - _Prompt: Role: MCP tool developer | Task: Add `save_review_batch` MCP tool following existing tool patterns | Restrictions: Use same ReviewService method as REST endpoint. Follow existing error dict pattern | Success: Task 3 の MCP ツールテストが全て GREEN_
+  - **完了基準**: `TestSaveReviewBatchTool` の全テストが GREEN
+  - **確認手順**: `uv run pytest tests/test_server.py::TestSaveReviewBatchTool -v` で全テストがパスする。`uv run ruff check src/insight_blueprint/server.py` がパスする
+
+## Phase 4: Frontend Types + Section Registry (test-design P4)
+
+- [x] 4. Add frontend types and API client functions
+  - File: `frontend/src/types/api.ts` (modify), `frontend/src/api/client.ts` (modify)
+  - Add to `types/api.ts`: `JsonValue` type alias, `BatchComment`, `ReviewBatch`, `DraftComment`, `SubmitBatchRequest` interfaces
+  - Add to `client.ts`: `submitReviewBatch(designId, body: SubmitBatchRequest)` → POST `/review-batches`, `listReviewBatches(designId)` → GET `/review-batches`
+  - Purpose: Frontend data layer for batch operations
+  - _Leverage: `types/api.ts` (existing `ReviewComment`, `DesignStatus`), `api/client.ts` (existing `request()` helper, `addComment` pattern)_
+  - _Requirements: FR-12, FR-13_
+  - _Prompt: Role: TypeScript developer | Task: Add review batch types and API client functions following existing patterns | Restrictions: Use existing `request<T>()` helper. `JsonValue` must match backend definition. Do not remove existing types | Success: Types compile, API functions match backend endpoint signatures_
+  - **完了基準**: 型定義と API クライアント関数が追加され、既存コードとの整合性がとれている
+  - **確認手順**: `cd frontend && npx tsc --noEmit` がパスする
+
+- [x] 4.1 Create `COMMENTABLE_SECTIONS` registry and `useReviewDrafts` hook
+  - File: `frontend/src/pages/design-detail/components/sections.ts` (new), `frontend/src/pages/design-detail/components/useReviewDrafts.ts` (new)
+  - Note: `frontend/src/pages/design-detail/components/` ディレクトリを新規作成する（SPEC-4b SRP パターン）
+  - Create `sections.ts` with `COMMENTABLE_SECTIONS` array: `{ id, label, type }` for 6 sections (`hypothesis_statement`, `hypothesis_background`, `metrics`, `explanatory`, `chart`, `next_action`)
+  - Create `useReviewDrafts` hook:
+    - State: `drafts: DraftComment[]` (React useState)
+    - `addDraft(section, comment, content)`: add with `crypto.randomUUID()` id and `structuredClone(content)` for snapshot
+    - `removeDraft(draftId)`: filter by id
+    - `clearAll()`: reset to empty
+    - `hasDrafts`: derived boolean
+    - `draftsBySection`: derived `Map<string, DraftComment[]>` (useMemo)
+    - `beforeunload` listener when `hasDrafts` is true
+  - Purpose: Section 定義の single source of truth + draft state management
+  - _Leverage: React hooks (useState, useEffect, useCallback, useMemo)_
+  - _Requirements: FR-5, NFR-5_
+  - _Prompt: Role: React developer | Task: Create sections registry and useReviewDrafts hook with structuredClone for snapshot immutability | Restrictions: React state only — no sessionStorage. Use structuredClone for content deep copy. Memoize draftsBySection. Section IDs must match backend ALLOWED_TARGET_SECTIONS | Success: Hook manages drafts correctly, beforeunload fires when drafts exist, snapshots are immutable copies_
+  - **完了基準**: `sections.ts` に6セクション定義、`useReviewDrafts.ts` に hook が実装され、`structuredClone` でスナップショットを取得している
+  - **確認手順**: `cd frontend && npx tsc --noEmit` がパスする
+
+- [x] 4.2 Add section definition sync contract test
+  - File: `tests/test_reviews.py` (modify)
+  - Add `TestSectionDefinitionSync` class with 1 test:
+    - Read frontend `COMMENTABLE_SECTIONS` from `frontend/src/pages/design-detail/components/sections.ts` (regex parse)
+    - Compare ID set with backend `ALLOWED_TARGET_SECTIONS` from `core/reviews.py`
+    - Assert equality
+  - Purpose: backend/frontend セクション ID のドリフトを自動検知する
+  - _Leverage: `core/reviews.py` (`ALLOWED_TARGET_SECTIONS`), `sections.ts` (`COMMENTABLE_SECTIONS`)_
+  - _Requirements: NFR-7_
+  - _Prompt: Role: Cross-stack test engineer | Task: Write contract test parsing frontend TypeScript source to extract section IDs and comparing with backend set | Restrictions: Use regex to parse TS source — do not import TypeScript. Test must fail if either side adds/removes a section without updating the other. Use explicit file path: `frontend/src/pages/design-detail/components/sections.ts` | Success: Test passes when sections match, fails when they drift_
+  - **完了基準**: `TestSectionDefinitionSync` が backend と frontend のセクション ID の一致を検証している
+  - **確認手順**: `uv run pytest tests/test_reviews.py::TestSectionDefinitionSync -v` がパスする
+
+## Phase 5: Frontend Components
+
+- [x] 5. Create `SectionRenderer`, `InlineCommentAnchor`, `DraftCommentForm` components
+  - File: `frontend/src/pages/design-detail/components/SectionRenderer.tsx` (new), `frontend/src/pages/design-detail/components/InlineCommentAnchor.tsx` (new), `frontend/src/pages/design-detail/components/DraftCommentForm.tsx` (new)
+  - `SectionRenderer`: renders a single design section (text via `<p>`, json via `JsonTree`), passes `structuredClone(value)` as target_content when adding draft
+  - `InlineCommentAnchor`: comment button (visible only in review mode), toggles `DraftCommentForm`
+  - `DraftCommentForm`: textarea + submit/cancel buttons, inline under section. Draft cards below with dashed border + "draft" label + delete button (one-click, no confirmation dialog)
+  - Purpose: SRP に分離されたインラインコメント UI コンポーネント
+  - _Leverage: `JsonTree` (json display), shadcn/ui `Button`, `Textarea`_
+  - _Requirements: FR-1, FR-2, FR-3, NFR-3, NFR-4, NFR-6, NFR-10, NFR-12_
+  - _Prompt: Role: React component developer | Task: Create 3 SRP components for inline commenting — renderer, anchor, and form | Restrictions: SectionRenderer under 100 lines. Use existing JsonTree for JSON sections. Draft cards must have dashed border and "draft" label (NFR-10). Delete is one-click, no confirmation (NFR-12). NEVER use `dangerouslySetInnerHTML` (NFR-6) | Success: Components render correctly, form submits draft, delete removes draft without dialog_
+  - **完了基準**: 3つのコンポーネントが作成され、ドラフトカードに破線ボーダー + "draft" ラベルが表示され、`dangerouslySetInnerHTML` が使用されていない
+  - **確認手順**: `cd frontend && npx tsc --noEmit` がパスする。`grep -r "dangerouslySetInnerHTML" frontend/src/pages/design-detail/components/` が 0件
+
+- [x] 5.1 Create `ReviewBatchComposer` component
+  - File: `frontend/src/pages/design-detail/components/ReviewBatchComposer.tsx` (new)
+  - Floating bar (sticky bottom): draft count badge + status selector (supported/rejected/inconclusive/active) + "Submit All" button
+  - Visible only when `hasDrafts` is true
+  - Status selector の選択肢定数を定義（旧 `ReviewPanel.tsx` の `COMMENT_STATUSES` 相当を移設）
+  - Submit: call `submitReviewBatch()`, on success call `onSubmitted()` + `onClearDrafts()`
+  - Submit button disabled during API call (double-submit prevention)
+  - On error: show error message via `ErrorBanner`, preserve drafts
+  - Purpose: Batch submission UI（ドラフト件数表示 + ステータス選択 + 一括投稿）
+  - _Leverage: `api/client.ts` (`submitReviewBatch`), shadcn/ui `Select`, `Button`, `Badge`, `ErrorBanner`_
+  - _Requirements: FR-6, FR-7, FR-8, FR-9, NFR-6, NFR-11_
+  - _Prompt: Role: React developer | Task: Create ReviewBatchComposer as sticky bottom bar with status selector and submit | Restrictions: Use `position: sticky; bottom: 0` (NFR-11). Disable submit button during API call. Show ErrorBanner on failure. NEVER use `dangerouslySetInnerHTML` (NFR-6) | Success: Bar appears when drafts exist, disappears when empty, submit sends batch and clears drafts_
+  - **完了基準**: sticky bottom で表示され、ステータスセレクタと Submit All ボタンが機能する。送信中は Submit ボタンが disabled
+  - **確認手順**: `cd frontend && npx tsc --noEmit` がパスする
+
+- [x] 5.2 Create `ReviewHistoryPanel` component
+  - File: `frontend/src/pages/design-detail/components/ReviewHistoryPanel.tsx` (new)
+  - Read-only history view — 旧 `ReviewPanel` のコンセプトを再設計
+  - Fetch batches via `listReviewBatches(designId)`
+  - Display each batch as a card: `StatusBadge`, reviewer, timestamp, comment list
+  - Each comment shows: comment text, `target_section` label, `target_content` quote block (via `JsonTree` for json, `<blockquote>` for text)
+  - Purpose: 過去の ReviewBatch を読み取り専用で表示（セクションスナップショット付き）
+  - _Leverage: `StatusBadge`, `JsonTree`, `formatDateTime` from existing code_
+  - _Requirements: FR-17, NFR-6_
+  - _Prompt: Role: React developer | Task: Create ReviewHistoryPanel that displays past batches with target_content quotes | Restrictions: Read-only — no edit/delete. Use JsonTree for JSON target_content, blockquote for text. Reuse StatusBadge. NEVER use `dangerouslySetInnerHTML` (NFR-6) | Success: Batches displayed in descending order with section labels and content quotes_
+  - **完了基準**: 過去の ReviewBatch を read-only 表示し、各コメントに `target_content` を引用表示する
+  - **確認手順**: `cd frontend && npx tsc --noEmit` がパスする
+
+## Phase 6: Frontend Integration
+
+- [x] 6. Restructure tabs and integrate inline comments into OverviewPanel
+  - File: `frontend/src/pages/design-detail/DesignDetail.tsx` (modify), `frontend/src/pages/design-detail/OverviewPanel.tsx` (modify)
+  - Change tabs: `overview | review | knowledge` → `overview | history | knowledge`
+  - Replace `review` tab content with `ReviewHistoryPanel`
+  - Refactor `OverviewPanel`:
+    - Replace static field rendering with `SectionRenderer` loop over `COMMENTABLE_SECTIONS`
+    - Integrate `useReviewDrafts` hook
+    - Add `ReviewBatchComposer` at bottom
+    - Pass `refreshDesign` callback to `ReviewBatchComposer.onSubmitted`
+    - Move "Submit for Review" button from `ReviewPanel` to Overview（status が `active` の時のみ表示）
+  - Remove import of `ReviewPanel` from `DesignDetail.tsx`
+  - Purpose: レビューワークフローを Overview タブに統合する
+  - _Leverage: `DesignDetail.tsx` (tab structure), `OverviewPanel.tsx` (field rendering), `ReviewPanel.tsx` (submit-for-review button logic)_
+  - _Requirements: FR-15, FR-16, NFR-4_
+  - _Prompt: Role: React developer with refactoring expertise | Task: Restructure tabs and integrate inline commenting into OverviewPanel | Restrictions: OverviewPanel must stay under 400 lines (NFR-4). Move submit-for-review button from ReviewPanel to Overview. Do not break KnowledgePanel | Success: 3 tabs (Overview/History/Knowledge), inline comments work without tab switch, OverviewPanel ≤ 400 lines_
+  - **完了基準**: タブが Overview | History | Knowledge の3つ。Overview で inline comment が可能。OverviewPanel ≤ 400行
+  - **確認手順**: `cd frontend && npx tsc --noEmit` がパスする。`wc -l frontend/src/pages/design-detail/OverviewPanel.tsx` が 400 以下
+
+- [x] 6.1 Clean up `ReviewPanel.tsx`
+  - File: `frontend/src/pages/design-detail/ReviewPanel.tsx` (delete or archive)
+  - Remove `ReviewPanel.tsx` — 機能は `OverviewPanel`（submit-for-review ボタン）と `ReviewHistoryPanel`（履歴表示）に分散済み
+  - Update `index.ts` の re-export を確認
+  - Verify no remaining imports of `ReviewPanel` in codebase
+  - Purpose: 旧コンポーネントの明示的クリーンアップ
+  - _Leverage: Task 6 で移設完了後のクリーンアップ_
+  - _Requirements: FR-15 (タブ再構成の一部)_
+  - _Prompt: Role: React developer | Task: Remove ReviewPanel.tsx after its responsibilities have been distributed | Restrictions: Verify zero references to ReviewPanel before deletion. Check index.ts re-exports | Success: No import errors, ReviewPanel fully replaced_
+  - **完了基準**: `ReviewPanel.tsx` が削除され、`ReviewPanel` への参照がコードベースに存在しない
+  - **確認手順**: `grep -r "ReviewPanel" frontend/src/ --include="*.ts" --include="*.tsx"` が 0件（ファイル自体を除く）。`cd frontend && npx tsc --noEmit` がパスする
+
+## Phase 7: E2E Tests (test-design P7 + P8 + P9)
+
+- [x] 7. Add E2E test fixtures and mock routes for review batches
+  - File: `frontend/e2e/fixtures/mock-data.ts` (modify), `frontend/e2e/fixtures/api-routes.ts` (modify)
+  - Add `makeBatchComment()` and `makeReviewBatch()` factory functions to `mock-data.ts`
+  - Add `mockReviewBatches(page, batches)` and `mockReviewBatchesError(page)` route helpers to `api-routes.ts`
+  - Purpose: E2E テストインフラ整備
+  - _Leverage: `mock-data.ts` (existing factory pattern: `makeComment`), `api-routes.ts` (existing route pattern: `mockComments`)_
+  - _Requirements: (infrastructure for FR-1 through FR-17 E2E tests)_
+  - _Prompt: Role: Playwright test infrastructure developer | Task: Add mock data factories and API route helpers for review batches | Restrictions: Follow existing factory and route patterns exactly. Include target_content in mock data | Success: Factories produce valid mock data, routes intercept GET/POST /review-batches correctly_
+  - **完了基準**: `makeBatchComment`, `makeReviewBatch`, `mockReviewBatches`, `mockReviewBatchesError` が追加されている
+  - **確認手順**: `cd frontend && npx tsc --noEmit` がパスする
+
+- [x] 7.1 Write E2E tests for tab restructuring (P7)
+  - File: `frontend/e2e/design-detail.spec.ts` (modify)
+  - Add `test.describe("Tab Restructuring")` block:
+    - tabs show Overview, History, Knowledge
+    - Review tab is removed
+    - inline comments available without tab switch on pending_review
+  - Purpose: タブ再構成の E2E 検証。test-design P7
+  - _Leverage: `frontend/e2e/design-detail.spec.ts` (existing test patterns), `mock-data.ts` / `api-routes.ts` (new fixtures)_
+  - _Requirements: FR-15, FR-16_
+  - _Prompt: Role: Playwright E2E test engineer | Task: Write E2E tests for tab restructuring verifying 3-tab layout | Restrictions: Use mock routes for API calls | Success: Tab structure verified, inline comments work without tab switch_
+  - **完了基準**: 3つのタブ構成テストが追加され、全テストが GREEN
+  - **確認手順**: `cd frontend && npx playwright test --grep "Tab Restructuring"` で全テストがパスする
+
+- [x] 7.2 Write E2E tests for inline comment flow (P8)
+  - File: `frontend/e2e/design-detail.spec.ts` (modify)
+  - Add `test.describe("Inline Review Comments")` block:
+    - Comment buttons: visible on pending_review, hidden on non-pending, click opens form
+    - Draft management: adding draft shows Submit Bar, removing all hides bar, count updates, status selector shows all 4 options
+    - Batch submission: Submit All sends batch + refreshes, target_content snapshot in POST body, drafts preserved on failure, submit button disabled during submission
+    - Visual/usability: draft visually distinct (dashed border), Submit Bar sticky
+  - Purpose: インラインコメントフローの E2E 検証。test-design P8
+  - _Leverage: `frontend/e2e/design-detail.spec.ts` (existing patterns), `mock-data.ts` / `api-routes.ts` (new fixtures)_
+  - _Requirements: FR-1, FR-2, FR-3, FR-5, FR-6, FR-7, FR-8, FR-9, NFR-10, NFR-11_
+  - _Prompt: Role: Playwright E2E test engineer | Task: Write comprehensive E2E tests for inline comment flow covering P8 test cases | Restrictions: Use mock routes for API calls. Check for visual indicators (dashed border class, sticky positioning). Intercept POST body to verify target_content | Success: All E2E tests pass, visual assertions confirmed, POST body contains target_content_
+  - **完了基準**: test-design.md P8 の全テストケースが E2E テストとして追加され、全テストが GREEN
+  - **確認手順**: `cd frontend && npx playwright test --grep "Inline Review Comments"` で全テストがパスする
+
+- [x] 7.3 Write E2E tests for History tab (P9)
+  - File: `frontend/e2e/design-detail.spec.ts` (modify)
+  - Add `test.describe("Review History")` block:
+    - History tab shows past review batches
+    - Batch displays comments with target_section labels
+    - Batch displays target_content alongside comments (blockquote for text, JSON tree for objects)
+    - Batches ordered by timestamp descending
+  - Purpose: History タブの E2E 検証。test-design P9
+  - _Leverage: `frontend/e2e/design-detail.spec.ts` (existing patterns), `mock-data.ts` (makeReviewBatch)_
+  - _Requirements: FR-17_
+  - _Prompt: Role: Playwright E2E test engineer | Task: Write E2E tests for History tab verifying batch display with target_content | Restrictions: Use mock routes with multiple batches. Verify target_content rendering | Success: All History tab tests pass, target_content displayed correctly_
+  - **完了基準**: 4つの E2E テストが追加され、全テストが GREEN
+  - **確認手順**: `cd frontend && npx playwright test --grep "Review History"` で全テストがパスする
+
+## Phase 8: Final Verification
+
+- [x] 8. Run full quality check and verify all requirements
+  - File: (all modified files)
+  - Run backend quality checks: `poe all` (lint + typecheck + test)
+  - Run frontend type check: `cd frontend && npx tsc --noEmit`
+  - Run Playwright E2E tests: `cd frontend && npx playwright test`
+  - Verify OverviewPanel line count ≤ 400 (NFR-4)
+  - Verify `dangerouslySetInnerHTML` not used in new components (NFR-6)
+  - Verify section definition sync contract test passes (NFR-7)
+  - Verify requirements traceability: all FR/NFR from test-design.md traceability matrix have corresponding passing tests
+  - Purpose: 全要件の最終検証
+  - _Leverage: `pyproject.toml` (poe tasks), test-design.md (traceability matrix)_
+  - _Requirements: All_
+  - _Prompt: Role: QA engineer | Task: Run full quality suite and verify all FR/NFR requirements are covered | Restrictions: Do not skip any check. Fix any failures before marking complete | Success: All checks pass, traceability matrix fully covered_
+  - **完了基準**: 全テスト GREEN、lint/type パス、NFR-4/NFR-6/NFR-7 の確認完了、traceability matrix の全項目にテストが存在する
+  - **確認手順**: `poe all && cd frontend && npx tsc --noEmit && npx playwright test` が全パスする

--- a/.spec-workflow/specs/inline-review-comments/test-design.md
+++ b/.spec-workflow/specs/inline-review-comments/test-design.md
@@ -1,0 +1,371 @@
+# Test Design: Inline Review Comments
+
+## Overview
+
+インラインレビューコメント機能のテスト設計（簡素化版）。レガシー互換・冪等性・sessionStorage 永続化を排除し、コア機能に集中する。TDD の Red-Green-Refactor サイクルに従い、テストを実装より先に書く。既存プロジェクトのテストパターン（class-based grouping、fixture composition、AC 参照 docstring）を踏襲する。
+
+## Test Scope
+
+| レイヤー | テスト種別 | フレームワーク | 対象 |
+|----------|-----------|---------------|------|
+| Models | Unit | pytest | `ReviewBatch`, `BatchComment` |
+| Service | Unit | pytest | `ReviewService` 拡張 |
+| REST API | Integration | pytest + TestClient | `/review-batches` |
+| MCP Tool | Integration | pytest + asyncio | `save_review_batch` tool |
+| Contract | Unit | pytest | Section 定義同期 |
+| Frontend | E2E | Playwright | インラインコメントフロー, History タブ |
+
+**フロントエンド Unit テストは対象外** — プロジェクトに vitest/jest は未導入。ロジックは E2E でカバーする。
+
+## Fixtures
+
+### 既存 fixtures（再利用）
+
+- `tmp_project(tmp_path)` — `.insight/` 初期化済みの一時プロジェクト
+- `design_service(tmp_path)` — DesignService インスタンス
+- `review_service(tmp_path, design_service)` — ReviewService インスタンス
+- `active_design(design_service)` — `active` ステータスの Design
+- `pending_design(design_service, review_service, active_design)` — `pending_review` の Design
+
+### 新規 fixtures（`conftest.py` に追加）
+
+```python
+@pytest.fixture
+def review_batch_data():
+    """有効な ReviewBatch 投稿リクエストの基本データ。"""
+    return {
+        "status_after": "supported",
+        "reviewer": "analyst",
+        "comments": [
+            {
+                "comment": "仮説の指標が曖昧",
+                "target_section": "hypothesis_statement",
+                "target_content": "〇〇の施策はCVRを改善する",
+            },
+            {
+                "comment": "KPI測定期間が未定義",
+                "target_section": "metrics",
+                "target_content": {"kpi_name": "CVR", "current_value": "2.5%"},
+            },
+        ],
+    }
+
+def make_batch_payload(**overrides):
+    """テスト用バッチ payload ファクトリ。有効/無効データの量産に使用。"""
+    base = {
+        "status_after": "supported",
+        "reviewer": "analyst",
+        "comments": [
+            {
+                "comment": "テストコメント",
+                "target_section": "hypothesis_statement",
+                "target_content": "テスト仮説",
+            },
+        ],
+    }
+    base.update(overrides)
+    return base
+
+@pytest.fixture
+def non_pending_design(design_service):
+    """draft ステータスの Design。投稿拒否テスト用。"""
+    return design_service.create_design(
+        hypothesis="テスト仮説", source_ids=["SRC-1"]
+    )
+
+@pytest.fixture
+def fixed_now(monkeypatch):
+    """now_jst() を固定時刻に差し替え。ソート安定化用。
+    Note: models/review.py 内の import にも対応するため両方 patch する。"""
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+    fixed = datetime(2026, 3, 1, 12, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
+    monkeypatch.setattr("insight_blueprint.models.common.now_jst", lambda: fixed)
+    monkeypatch.setattr("insight_blueprint.models.review.now_jst", lambda: fixed)
+    return fixed
+
+@pytest.fixture
+def corrupted_reviews_yaml(tmp_path):
+    """パース不能な reviews YAML ファイル。YAML 破損テスト用。"""
+    path = tmp_path / ".insight" / "designs" / "DES-corrupt_reviews.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("batches:\n  - invalid: [unclosed bracket", encoding="utf-8")
+    return path
+
+@pytest.fixture
+def status_update_failure(monkeypatch, design_service):
+    """DesignService のステータス更新を強制失敗させる。原子性テスト用。"""
+    original = design_service.update_status
+    def fail_update(*args, **kwargs):
+        raise RuntimeError("Simulated status update failure")
+    monkeypatch.setattr(design_service, "update_status", fail_update)
+    return original
+```
+
+## Unit Tests: Models
+
+### ファイル: `tests/test_review_models.py`（既存に追加）
+
+```
+class TestBatchComment:
+    test_valid_batch_comment                    # FR-11: comment + target_section + target_content で生成できる
+    test_target_section_optional                # FR-11: target_section は None 許容
+    test_target_content_optional_when_no_section  # FR-11: target_section=None なら target_content=None 許容
+    test_target_section_requires_target_content # FR-11: target_section set + target_content=None → ValidationError
+    test_target_content_preserves_text          # FR-11: text 型セクションの内容保持
+    test_target_content_preserves_json          # FR-11: json 型セクションの内容保持（dict/list）
+    test_target_content_rejects_non_json_values # JsonValue: datetime/set 等の非 JSON 互換値を拒否（parametrize）
+    test_empty_comment_rejected                 # 空文字コメントを拒否
+    test_whitespace_only_comment_rejected       # 空白のみコメント（"   "）を拒否
+    test_comment_max_length_boundary            # 2000文字ちょうど → 許可
+    test_comment_over_max_length_rejected       # 2001文字 → 拒否
+    test_empty_string_target_section_rejected   # target_section="" を拒否（None のみ許容）
+    test_extra_field_rejected                   # extra="forbid": 未知フィールドで ValidationError
+
+class TestReviewBatch:
+    test_valid_review_batch                     # FR-10: 全フィールドで生成できる
+    test_id_format                              # FR-10: id は "RB-" prefix + 8文字 hex
+    test_status_after_must_be_valid             # FR-10: 不正ステータスを拒否
+    test_comments_must_not_be_empty             # FR-10: コメント0件を拒否
+    test_created_at_defaults_to_jst             # FR-10: デフォルトで JST タイムスタンプ
+    test_reviewer_defaults_to_analyst           # FR-10: reviewer のデフォルト値
+    test_json_round_trip                        # シリアライズ→デシリアライズの一貫性（target_content 含む）
+    test_extra_field_rejected                   # extra="forbid": 未知フィールドで ValidationError
+```
+
+## Unit Tests: ReviewService
+
+### ファイル: `tests/test_reviews.py`（既存に追加）
+
+```
+class TestSaveReviewBatch:
+    test_save_batch_with_valid_data             # FR-8, FR-12: 正常系。バッチ保存 + ステータス遷移
+    test_save_batch_transitions_design_status   # FR-8: Design ステータスが status_after に遷移する
+    test_save_batch_persists_to_yaml            # FR-14: YAML ファイルに永続化される
+    test_save_batch_preserves_target_section    # FR-4: 各コメントの target_section が保存される
+    test_save_batch_preserves_target_content_text   # FR-11: text 型 target_content が保存される
+    test_save_batch_preserves_target_content_json   # FR-11: json 型 target_content が保存される
+    test_save_batch_rejects_non_pending_review  # AC: pending_review でない場合 ValueError
+    test_save_batch_rejects_invalid_status      # 不正な status_after を拒否
+    test_save_batch_rejects_empty_comments      # コメント0件を拒否
+    test_save_batch_rejects_invalid_design_id   # パストラバーサル等の不正 ID を拒否（parametrize）
+    test_save_batch_missing_design              # 存在しない design_id で None 返却
+    test_save_batch_yaml_write_failure_no_status_change  # NFR-8, NFR-9: YAML 書き込み失敗時ステータス未遷移
+    test_save_batch_status_update_failure_keeps_batch  # NFR-8: YAML 成功 → ステータス更新失敗 → バッチは保存済み
+    test_save_batch_all_status_transitions      # FR-7: supported/rejected/inconclusive/active 全遷移（parametrize）
+    test_save_batch_appends_to_existing_batches # 既存バッチがあるファイルに追記される
+    test_save_batch_creates_new_file            # reviews.yaml が存在しない場合に新規作成
+
+class TestSaveReviewBatchTargetSectionValidation:
+    test_valid_target_sections_accepted          # NFR-7: 6セクション全てが通る（parametrize）
+    test_invalid_target_section_rejected          # NFR-7: 不正なセクション名を拒否
+    test_null_target_section_accepted             # NFR-7: None は許容（アンカーなしコメント）
+
+class TestListReviewBatches:
+    test_list_batches_returns_all                # FR-13: 全バッチを返す
+    test_list_batches_descending_order           # FR-13: created_at 降順
+    test_list_batches_empty                      # バッチなしで空リスト
+    test_list_batches_nonexistent_design         # 存在しない design_id で空リスト
+    test_list_batches_no_file                    # reviews.yaml が存在しない場合に空リスト
+    test_list_batches_no_batches_key             # YAML に batches キーがない場合に空リスト + warning log
+    test_list_batches_preserves_target_content   # target_content がバッチ取得時に保持される
+    test_list_batches_corrupted_yaml             # Error#7: YAML 破損時に空リスト + warning log
+```
+
+## Contract Tests: Section Definition Sync
+
+### ファイル: `tests/test_reviews.py`（既存に追加）
+
+```
+class TestSectionDefinitionSync:
+    test_allowed_sections_matches_commentable_sections  # NFR-7: backend ALLOWED_TARGET_SECTIONS と frontend COMMENTABLE_SECTIONS の ID 集合が一致する
+```
+
+**Note**: フロントエンドの `COMMENTABLE_SECTIONS` 定義ファイルを読み取り、バックエンドの `ALLOWED_TARGET_SECTIONS` と ID セットが一致するかを検証する。セクション追加漏れの自動検知。
+
+## Integration Tests: REST API
+
+### ファイル: `tests/test_web.py`（既存に追加）
+
+```
+class TestReviewBatchAPI:
+    # POST /api/designs/{id}/review-batches
+    test_submit_batch_success                    # FR-12: 正常系。201 + batch_id 返却
+    test_submit_batch_transitions_status         # FR-8: ステータス遷移確認
+    test_submit_batch_all_statuses               # FR-7: supported/rejected/inconclusive/active（parametrize）
+    test_submit_batch_non_pending_returns_400    # AC: pending_review でなければ 400
+    test_submit_batch_invalid_design_returns_404 # Error#5: 存在しない design_id で 404
+    test_submit_batch_invalid_section_returns_422 # NFR-7: 不正 target_section で 422（レスポンスに field 名含む）
+    test_submit_batch_empty_comments_returns_422  # Error#6: コメント0件で 422
+    test_submit_batch_overlength_comment_returns_422  # Error#6: 2001文字コメントで 422
+    test_submit_batch_missing_target_content_returns_422  # FR-11: target_section set + target_content なしで 422
+    test_submit_batch_extra_field_returns_422     # extra="forbid": 未知フィールドで 422
+    test_submit_batch_with_target_content        # FR-11: target_content の round-trip 確認
+
+    # GET /api/designs/{id}/review-batches
+    test_list_batches_success                    # FR-13: 正常系。バッチリスト返却
+    test_list_batches_empty                      # バッチなしで空リスト
+    test_list_batches_descending_order           # FR-13: 降順ソート
+    test_list_batches_includes_target_content    # FR-11: レスポンスに target_content 含む
+```
+
+## Integration Tests: MCP Tool
+
+### ファイル: `tests/test_server.py`（既存に追加）
+
+```
+class TestSaveReviewBatchTool:
+    test_save_review_batch_tool_success          # FR-18: 正常系。バッチ作成 + ステータス遷移
+    test_save_review_batch_tool_with_sections    # FR-18: target_section + target_content 付きコメント
+    test_save_review_batch_tool_non_pending      # FR-18: pending_review でなければエラー
+```
+
+## E2E Tests: Playwright
+
+### ファイル: `frontend/e2e/design-detail.spec.ts`（既存に追加）
+
+```
+test.describe("Inline Review Comments", () => {
+    // Tab Restructuring (FR-15, FR-16)
+    test("tabs show Overview, History, Knowledge")
+    test("Review tab is removed")
+    test("inline comments available without tab switch on pending_review")  // FR-16
+
+    // Comment Buttons (FR-1, FR-2, FR-3)
+    test("comment buttons visible on pending_review design")
+    test("comment buttons hidden on non-pending_review design")
+    test("clicking comment button opens inline form")
+
+    // Draft Management (FR-5, FR-6, FR-7)
+    test("adding draft shows Review Submit Bar")
+    test("removing all drafts hides Submit Bar")
+    test("Submit Bar shows draft count")
+    test("adding drafts to multiple sections updates count")
+    test("status selector shows all 4 options")  // FR-7
+
+    // Batch Submission (FR-8, FR-9)
+    test("Submit All sends batch and refreshes design")
+    test("Submit All sends target_content snapshot in POST body")  // FR-11: スナップショット送信確認
+    test("drafts preserved on submission failure")
+    test("Submit button disabled during submission")
+
+    // Visual / Usability (NFR-10, NFR-11)
+    test("draft comments visually distinct from submitted")  // NFR-10
+    test("Submit Bar sticky at bottom")  // NFR-11
+})
+```
+
+### ファイル: `frontend/e2e/history.spec.ts`（既存に追加）
+
+```
+test.describe("Review History", () => {
+    // History Tab (FR-17)
+    test("History tab shows past review batches")
+    test("batch displays comments with target_section labels")
+    test("batch displays target_content alongside comments")  // FR-17: スナップショット表示
+    test("batches ordered by timestamp descending")
+})
+```
+
+### Mock Data 追加（`frontend/e2e/fixtures/mock-data.ts`）
+
+```typescript
+export function makeBatchComment(overrides?: Partial<BatchComment>): BatchComment {
+    return {
+        comment: "テストコメント",
+        target_section: "hypothesis_statement",
+        target_content: "テスト仮説の内容",
+        ...overrides,
+    };
+}
+
+export function makeReviewBatch(overrides?: Partial<ReviewBatch>): ReviewBatch {
+    return {
+        id: "RB-test0001",
+        design_id: "DES-test",
+        status_after: "supported",
+        reviewer: "analyst",
+        comments: [makeBatchComment()],
+        created_at: "2026-03-01T10:00:00+09:00",
+        ...overrides,
+    };
+}
+```
+
+### API Route 追加（`frontend/e2e/fixtures/api-routes.ts`）
+
+```typescript
+export function mockReviewBatches(page: Page, batches: ReviewBatch[] = []) {
+    return page.route("**/api/designs/*/review-batches", (route) => {
+        if (route.request().method() === "GET") {
+            route.fulfill({ json: { batches, count: batches.length } });
+        } else if (route.request().method() === "POST") {
+            route.fulfill({
+                status: 201,
+                json: { batch_id: "RB-new00001", status_after: "supported", comment_count: 1 },
+            });
+        }
+    });
+}
+
+export function mockReviewBatchesError(page: Page) {
+    return page.route("**/api/designs/*/review-batches", (route) => {
+        if (route.request().method() === "POST") {
+            route.fulfill({ status: 500, json: { error: "Internal Server Error" } });
+        }
+    });
+}
+```
+
+## Test Priority（実装順序）
+
+TDD の Red-Green-Refactor で、以下の順にテスト→実装を進める。P1 内で model_validator / extra=forbid / JsonValue 制約を最初に固める。
+
+| Priority | テスト対象 | 理由 |
+|----------|-----------|------|
+| **P1** | `BatchComment` / `ReviewBatch` モデル（validator, extra=forbid, JsonValue 含む） | 他の全てがこのモデルに依存。バリデーション契約を最初に固める |
+| **P2** | `ReviewService.save_review_batch()` + YAML 永続化 + 原子性 | コアビジネスロジック + 永続化契約 + 操作順序を同時に固める |
+| **P3** | `ReviewService.list_review_batches()` + YAML 破損ハンドリング | 読み取り系。異常系（破損ファイル）含む |
+| **P4** | Contract: Section 定義同期 | backend/frontend の整合性保証 |
+| **P5** | REST API エンドポイント | サービス層のトランスポート |
+| **P6** | MCP ツール | REST API と同一サービス層を使用 |
+| **P7** | E2E: タブ再構成 | フロントエンドの骨格 |
+| **P8** | E2E: インラインコメントフロー + スナップショット送信 | フルフロー |
+| **P9** | E2E: History タブ + target_content 表示 | 読み取り系 UI + スナップショット表示 |
+
+## Requirements Traceability
+
+全 FR/NFR を網羅。自動テスト対象外の項目は根拠と代替手段を明記。
+
+| Requirement | テストケース | 備考 |
+|-------------|-------------|------|
+| FR-1 | E2E: comment buttons visible on pending_review | |
+| FR-2 | E2E: comment buttons hidden on non-pending_review | |
+| FR-3 | E2E: clicking comment button opens inline form | |
+| FR-4 | TestSaveReviewBatch.test_save_batch_preserves_target_section | |
+| FR-5 | E2E: adding draft shows Review Submit Bar | |
+| FR-6 | E2E: Submit Bar shows draft count, adding drafts to multiple sections updates count | |
+| FR-7 | E2E: status selector shows all 4 options, TestSaveReviewBatch.test_save_batch_all_status_transitions, TestReviewBatchAPI.test_submit_batch_all_statuses | |
+| FR-8 | TestSaveReviewBatch.test_save_batch_transitions_design_status, TestReviewBatchAPI.test_submit_batch_transitions_status | |
+| FR-9 | E2E: Submit All sends batch and refreshes design | |
+| FR-10 | TestReviewBatch (全テスト) | |
+| FR-11 | TestBatchComment (全テスト含む validator/JsonValue), TestSaveReviewBatch.test_save_batch_preserves_target_content_*, TestReviewBatchAPI.test_submit_batch_with/missing_target_content, E2E: Submit All sends target_content | model_validator + JsonValue + round-trip |
+| FR-12 | TestReviewBatchAPI.test_submit_batch_success | |
+| FR-13 | TestListReviewBatches.test_list_batches_returns_all, TestReviewBatchAPI.test_list_batches_success | |
+| FR-14 | TestSaveReviewBatch.test_save_batch_persists_to_yaml | |
+| FR-15 | E2E: tabs show Overview, History, Knowledge | |
+| FR-16 | E2E: inline comments available without tab switch on pending_review | |
+| FR-17 | E2E: History tab shows past review batches, batch displays target_section labels, batch displays target_content alongside comments | |
+| FR-18 | TestSaveReviewBatchTool.test_save_review_batch_tool_success | |
+| NFR-1 | — | 構造規約。コードレビューで確認（ファイル配置） |
+| NFR-2 | — | 構造規約。コードレビューで確認（ファイル配置） |
+| NFR-3 | — | 構造規約。コードレビューで確認（ファイル配置） |
+| NFR-4 | — | 構造規約。実装後に `wc -l` で行数確認 |
+| NFR-5 | — | 構造規約。React DevTools Profiler で再レンダリング確認 |
+| NFR-6 | — | `Manual`: E2E で XSS payload を入力し、エスケープを目視確認 |
+| NFR-7 | TestSaveReviewBatchTargetSectionValidation (全テスト), TestSectionDefinitionSync | バリデーション + backend/frontend 同期契約 |
+| NFR-8 | TestSaveReviewBatch.test_save_batch_yaml_write_failure_no_status_change, test_save_batch_status_update_failure_keeps_batch | YAML 失敗・ステータス失敗の両方向 |
+| NFR-9 | TestSaveReviewBatch.test_save_batch_yaml_write_failure_no_status_change | NFR-8 と同一テストでカバー |
+| NFR-10 | E2E: draft comments visually distinct from submitted | CSS クラス存在チェック |
+| NFR-11 | E2E: Submit Bar sticky at bottom | viewport 内に表示されるかチェック |
+| NFR-12 | E2E: removing all drafts hides Submit Bar | |

--- a/.spec-workflow/specs/skills-distribution/design.md
+++ b/.spec-workflow/specs/skills-distribution/design.md
@@ -1,0 +1,246 @@
+# Design — SPEC-5: skills-distribution
+
+## Overview
+
+SPEC-5 は insight-blueprint を PyPI 配布可能な状態にする最終スペック。既存の `_copy_skills_template()` を version-aware な更新機構に拡張し、bundled skills をバイリンガル化し、パッケージメタデータ・README を整備する。主な変更は `storage/project.py` のスキルコピーロジックと、`_skills/` 内の SKILL.md ファイル、`pyproject.toml`、`README.md`。
+
+## Steering Document Alignment
+
+### Technical Standards (tech.md)
+
+- **Build backend**: hatchling（変更なし）。`_skills/` は `packages` パス内なので wheel に自動含有
+- **Skills path resolution**: `importlib.resources.files("insight_blueprint")` を継続使用
+- **Skill frontmatter**: `version` フィールドを追加（tech.md に反映済み）
+- **Update mechanism**: tech.md に記載済み — version 比較 + カスタマイズ検出 + `.bundled-update`
+- **Language**: body は英語、`description` はバイリンガル、応答言語は CLAUDE.md 委譲（tech.md に反映済み）
+
+### Project Structure (structure.md)
+
+- SPEC-5 対象モジュール: `_skills/`, `README.md`, `pyproject.toml`, `LICENSE`
+- `storage/project.py` の `_copy_skills_template()` を拡張（新ファイル作成なし）
+- リリース手順書: `docs/RELEASE.md`（新規）
+
+## Code Reuse Analysis
+
+### Existing Components to Leverage
+
+- **`storage/project.py`**: `_copy_skills_template()` — 拡張対象。`importlib.resources.files()` パターンはそのまま再利用
+- **`storage/project.py`**: `_register_mcp_server()` — atomic write パターン（`tempfile.mkstemp` + `os.replace`）を `.bundled-update` 書き出しでも再利用
+- **`storage/yaml_store.py`**: YAML frontmatter パース — SKILL.md の `version` 読み取りに活用可能だが、SKILL.md は ruamel.yaml ではなく YAML frontmatter（`---` 区切り）なので標準的な文字列パースで十分
+
+### Integration Points
+
+- **`cli.py`**: `init_project()` 呼び出し経路は変更なし。ログ出力のみ追加
+- **`_skills/`**: SKILL.md ファイルのみ変更。Python コードへの影響なし
+- **`pyproject.toml`**: メタデータ追加のみ。build 設定は変更なし
+
+## Architecture
+
+SPEC-5 は新しいアーキテクチャパターンを導入しない。既存の `init_project()` → `_copy_skills_template()` フローを拡張する。
+
+```
+init_project(project_path)
+  ├── _create_insight_dirs()      # 変更なし
+  ├── _copy_skills_template()     # ★ 拡張: version-aware update
+  │     ├── _discover_bundled_skills()     # 新規: _skills/ 自動検出
+  │     ├── _get_skill_version()           # 新規: frontmatter version 読み取り
+  │     ├── _hash_skill_directory()        # 新規: ディレクトリ全体の SHA-256
+  │     ├── _load_skill_state()            # 新規: state.json 読み取り
+  │     ├── _save_skill_state()            # 新規: state.json 書き込み
+  │     ├── _copy_skill_tree()             # 新規: Traversable API 再帰コピー
+  │     └── _write_bundled_update()        # 新規: .bundled-update.json 書き出し
+  └── _register_mcp_server()      # 変更なし
+```
+
+### Update Decision Logic
+
+Codex レビュー（`.claude/docs/research/SPEC-5-codex-design-review.md`）の指摘を反映し、version + hash の2軸で判定する。
+
+```python
+# Pseudocode: _copy_skills_template() per-skill logic
+for skill_name in _discover_bundled_skills():
+    dest = project_path / ".claude" / "skills" / skill_name
+    bundled_version = _get_skill_version(bundled_path / "SKILL.md")
+    bundled_hash = _hash_skill_directory(bundled_path)
+
+    if not dest.exists():
+        # Case 1: 初回コピー
+        _copy_skill_tree(bundled_path, dest)
+        _save_skill_state(dest, bundled_version, bundled_hash)
+        continue
+
+    state = _load_skill_state(dest)
+    installed_version = state.get("installed_version")
+
+    if bundled_version and installed_version:
+        if Version(bundled_version) <= Version(installed_version):
+            # Case 2: 同 version or downgrade → 何もしない
+            continue
+
+    # bundled が新しい → ユーザーカスタマイズ判定
+    installed_hash = _hash_skill_directory(dest, exclude_managed=True)
+    prev_bundled_hash = state.get("installed_bundled_hash")
+
+    if prev_bundled_hash and installed_hash == prev_bundled_hash:
+        # Case 3: 未編集 → 自動更新
+        _copy_skill_tree(bundled_path, dest)
+        _save_skill_state(dest, bundled_version, bundled_hash)
+    else:
+        # Case 4: ユーザー編集済み → スキップ + 通知
+        logger.warning("Skill '%s' v%s available (customized, skipped)", ...)
+        _write_bundled_update(bundled_path, dest, bundled_version, installed_version)
+```
+
+### Modular Design Principles
+
+- **Single File Responsibility**: スキル更新ロジックは全て `storage/project.py` に閉じる。ヘルパー関数を追加するが新ファイルは作らない（YAGNI）。ファイル長が 800行を超える場合のみ `storage/skill_updater.py` への分離を検討
+- **Component Isolation**: SKILL.md のバイリンガル化は Python コードに影響しない。パッケージメタデータは `pyproject.toml` に閉じる
+- **Service Layer Separation**: スキルコピーは storage layer の責務。core/ には触れない
+- **Utility Modularity**: frontmatter パースは `_get_skill_version()` として分離。将来他の frontmatter フィールドが必要になっても拡張可能
+
+## Components and Interfaces
+
+### Component 1: Skill Update Engine (`storage/project.py`)
+
+- **Purpose:** bundled skills の自動検出・version-aware コピー・カスタマイズ検出・通知
+- **Interfaces:**
+  - `_copy_skills_template(project_path: Path) -> None` — 既存 signature 維持
+  - `_discover_bundled_skills() -> list[str]` — `_skills/` 配下で `SKILL.md` を含むディレクトリ名一覧を返す
+  - `_get_skill_version(skill_md_path: Path) -> str | None` — SKILL.md frontmatter から `version` を読み取り。パースエラー時は `None`
+  - `_hash_skill_directory(skill_dir: Path, exclude_managed: bool = False) -> str` — ディレクトリ全体の SHA-256。`exclude_managed=True` で `.insight-blueprint-state.json` と `.bundled-update.json` を除外。行末正規化（LF 統一）してから hash
+  - `_load_skill_state(skill_dir: Path) -> dict` — `.insight-blueprint-state.json` を読み取り。欠損時は空 dict
+  - `_save_skill_state(skill_dir: Path, version: str | None, bundled_hash: str) -> None` — state を JSON で保存
+  - `_copy_skill_tree(src: Traversable, dest: Path) -> None` — `importlib.resources.files` の `Traversable` API で再帰コピー。`shutil.copytree(str(src))` は使わない（importer 依存を避ける）
+  - `_write_bundled_update(bundled_path: Traversable, dest_dir: Path, new_version: str | None, old_version: str | None) -> None` — `.bundled-update.json` に新バージョン情報を書き出し
+- **Dependencies:** `importlib.resources`, `hashlib`, `json`, `logging`, `packaging.version`（version 比較用。`packaging` は pip/setuptools 経由で常にインストール済み）
+- **Reuses:** 既存の `importlib.resources.files()` パターン、atomic write パターン
+
+### Component 2: Bundled Skills (`_skills/`)
+
+- **Purpose:** Claude Code ユーザー向けのバイリンガルスキルテンプレート
+- **Interfaces:** YAML frontmatter（`name`, `description`, `version`, `disable-model-invocation`）
+- **Dependencies:** なし（テキストファイル）
+- **Reuses:** 既存の SKILL.md 構造
+
+### Component 3: Package Metadata (`pyproject.toml`, `LICENSE`, `README.md`)
+
+- **Purpose:** PyPI 配布に必要なメタデータとドキュメント
+- **Interfaces:** なし（静的ファイル）
+- **Dependencies:** なし
+- **Reuses:** 既存の `pyproject.toml` 構造
+
+## Data Models
+
+### SKILL.md Frontmatter（拡張）
+
+```yaml
+---
+name: analysis-design          # 既存
+version: "1.0.0"               # ★ 新規: semver
+description: |                 # 既存（内容をバイリンガル化）
+  English description here.
+  Triggers: "create analysis design", "分析設計を作りたい", ...
+disable-model-invocation: true # 既存
+argument-hint: "[theme_id]"    # 既存
+---
+```
+
+### Skill State File
+
+コピー時の状態を記録し、次回の更新判定に使用する。
+
+```
+.claude/skills/<name>/.insight-blueprint-state.json
+```
+
+```json
+{
+  "installed_version": "1.0.0",
+  "installed_bundled_hash": "sha256:abc123...",
+  "updated_at": "2026-02-28T12:00:00Z"
+}
+```
+
+- `installed_version`: コピー元 bundled skill の version（frontmatter から取得）
+- `installed_bundled_hash`: コピー時のスキルディレクトリ全体の SHA-256 hash
+- `updated_at`: 最終コピー/更新の ISO 8601 タイムスタンプ
+
+**判定ロジック**: `installed_bundled_hash` と現在の installed ディレクトリの hash を比較。一致すれば未編集（自動更新可）、不一致ならユーザー編集済み（スキップ + 通知）。
+
+### Bundled Update Notification
+
+ユーザー編集済みスキルのスキップ時に書き出す通知ファイル。
+
+```
+.claude/skills/<name>/.bundled-update.json
+```
+
+```json
+{
+  "from_version": "1.0.0",
+  "to_version": "1.1.0",
+  "created_at": "2026-02-28T12:00:00Z",
+  "message": "Run: diff .claude/skills/analysis-design/SKILL.md .claude/skills/analysis-design/.bundled-update/SKILL.md"
+}
+```
+
+さらに `.bundled-update/` ディレクトリに新バージョンのスキルファイル一式をコピーし、ユーザーが diff で差分確認・手動マージできるようにする。
+
+**Hash 計算からの除外**: `.insight-blueprint-state.json`, `.bundled-update.json`, `.bundled-update/` は hash 計算時に除外する（managed files）。
+
+## Error Handling
+
+### Error Scenarios
+
+1. **`_skills/` ディレクトリが空（skill が0個）**
+   - **Handling:** `_discover_bundled_skills()` が空リストを返す。ループが回らず正常終了
+   - **User Impact:** なし。スキルなしで起動
+
+2. **SKILL.md に `version` フィールドがない（古い形式）**
+   - **Handling:** `_get_skill_version()` が `None` を返す。version が `None` の場合は従来動作（dest.exists() なら skip）にフォールバック
+   - **User Impact:** なし。既存動作と同一
+
+3. **`.bundled-hash` ファイルが欠損（手動削除等）**
+   - **Handling:** hash ファイルがなければ「カスタマイズ済み」と判定（安全側に倒す）。更新スキップ + `.bundled-update` 書き出し
+   - **User Impact:** warning ログで通知。ユーザーは `.bundled-update` で diff 確認可能
+
+4. **SKILL.md の frontmatter パースエラー**
+   - **Handling:** パースエラー時は version `None` として扱い、従来動作にフォールバック
+   - **User Impact:** warning ログのみ。起動は継続
+
+5. **`.bundled-update.json` の書き込み失敗（permission 等）**
+   - **Handling:** 例外をキャッチし warning ログ。スキル更新処理全体は継続
+   - **User Impact:** 通知ファイルが作成されないが、warning ログで状況は伝わる
+
+6. **不正な version 文字列（`v1`, `latest` 等）**
+   - **Handling:** `packaging.version.Version` でパース。`InvalidVersion` 例外時は version `None` として扱い、従来動作にフォールバック
+   - **User Impact:** warning ログのみ
+
+7. **Downgrade（bundled version < installed version）**
+   - **Handling:** `Version(bundled) <= Version(installed)` の場合は何もしない。Downgrade は明示的に行わない
+   - **User Impact:** なし
+
+8. **部分更新失敗（コピー途中でエラー）**
+   - **Handling:** `_copy_skill_tree()` は既存ディレクトリを一旦 `.backup` にリネーム → 新規コピー → 成功したら `.backup` を削除。失敗したら `.backup` をリストアする
+   - **User Impact:** 中途半端な状態にならない。エラー時は元の状態を維持
+
+## Testing Strategy
+
+### Unit Testing
+
+- `_discover_bundled_skills()`: `_skills/` 配下に0個・1個・複数のディレクトリがある場合。`SKILL.md` なしディレクトリは除外
+- `_get_skill_version()`: version あり・version なし・frontmatter 不正・不正 version 文字列
+- `_hash_skill_directory()`: 正常 hash・managed files 除外・行末正規化（LF/CRLF 混在）
+- `_load_skill_state()` / `_save_skill_state()`: 正常読み書き・state.json 欠損・不正 JSON
+- `_copy_skill_tree()`: Traversable からの再帰コピー・部分失敗時のリストア
+- `_write_bundled_update()`: 正常書き出し・書き込み先 permission エラー
+- `_copy_skills_template()` 統合: 新規コピー・version アップ（未編集）・version アップ（編集済み）・同 version・downgrade・version なし旧 skill
+
+### Integration Testing
+
+- `init_project()` の E2E: 空ディレクトリから `init_project()` → skills がコピーされる → 再度 `init_project()`（version 同じ）→ 変更なし → SKILL.md 編集 → bundled version 上げ → 再度 `init_project()` → `.bundled-update` が書き出される
+- wheel build: `uv build` → wheel 内に `_skills/` と `static/` が含まれることを検証
+
+### End-to-End Testing
+
+- ローカル wheel インストール: `uv build` → `pip install dist/*.whl` → `insight-blueprint --project /tmp/test` → `.claude/skills/` にスキルがコピーされ WebUI が起動する

--- a/.spec-workflow/specs/skills-distribution/requirements.md
+++ b/.spec-workflow/specs/skills-distribution/requirements.md
@@ -1,0 +1,130 @@
+# Requirements — SPEC-5: skills-distribution
+
+## はじめに
+
+SPEC-5 はロードマップ最終スペック。PyPI 公開に向けて以下を整備する:
+1. bundled skills のバイリンガル化（英語本体 + 日本語トリガー）
+2. PyPI メタデータ・LICENSE・README 整備
+3. wheel に全 artifact（skills, static frontend）が含まれることの検証
+
+## Product Vision との対応
+
+1. **Zero-install** — `uvx insight-blueprint --project /path` で動く。wheel に全部入っていることが前提
+2. **OSS (MIT) on PyPI** — LICENSE、classifiers、メタデータを整備して PyPI に正しく表示
+3. **Bundled Skills** — `_skills/` から `.claude/skills/` へコピー。日英どちらのトリガーでも発見可能にする
+
+## 要件
+
+### 1. Skill バイリンガル化
+
+**User Story:** Claude Code ユーザー（日英問わず）として、自分の言語でスキルを呼び出したい。
+
+- FR-1: SKILL.md 本体（workflow, rules 等）は英語で記述
+- FR-2: `description` YAML フィールドに英語説明 + 日本語トリガーフレーズを併記
+- FR-3: `## Language Rules` セクションで「プロジェクトの CLAUDE.md の言語設定に従う。設定がなければ日本語をデフォルトとする。code/ID は常に英語」と明記
+- FR-4: `.claude/rules/skill-format.md` の YAML frontmatter スキーマに準拠
+
+#### Acceptance Criteria
+
+1. WHEN "create analysis design" 入力 THEN `analysis-design` skill が発見できる
+2. WHEN "分析設計を作りたい" 入力 THEN `analysis-design` skill が発見できる
+3. WHEN "catalog register" 入力 THEN `catalog-register` skill が発見できる
+4. WHEN "データカタログ登録" 入力 THEN `catalog-register` skill が発見できる
+5. WHEN skill 起動 AND CLAUDE.md に言語設定なし THEN ユーザーへの応答はデフォルト日本語
+6. WHEN skill 起動 AND CLAUDE.md に `Language: English` 設定あり THEN ユーザーへの応答は英語
+
+### 2. PyPI パッケージメタデータ
+
+**User Story:** PyPI を閲覧する開発者として、license・author・classifiers が表示されていてほしい。
+
+- FR-5: `pyproject.toml` に `license`, `authors`, `classifiers`, `urls` を追加
+- FR-6: リポジトリ root に MIT `LICENSE` ファイルを配置
+- FR-7: classifiers に Development Status, License, Python 3.11+, Topic, Framework を含める
+- FR-8: urls に Homepage, Repository, Bug Tracker を含める
+
+#### Acceptance Criteria
+
+1. WHEN `uv build` THEN wheel metadata に license, author, classifiers が含まれる
+2. WHEN PyPI ページ表示 THEN sidebar に MIT, Python >=3.11, project URLs が表示される
+
+### 3. README 整備
+
+**User Story:** PyPI / GitHub 訪問者として、insight-blueprint が何か・どう使うかをすぐ理解したい。
+
+- FR-9: README.md に概要、インストール（`uvx` / `uv tool install`）、Quick Start、機能一覧（MCP tools, WebUI, Skills）、開発セットアップを記載
+- FR-10: `pyproject.toml` の `readme = "README.md"` で long_description として使用（設定済み）
+- FR-11: claude-code-orchestra 固有コンテンツ（Codex CLI, Gemini CLI, spec-workflow-mcp 等）を削除または別ファイルに移動
+
+#### Acceptance Criteria
+
+1. WHEN README を読む THEN 最初の3セクションで「何か・インストール・使い方」が分かる
+2. WHEN `uv build` THEN wheel の long_description が README.md から生成される
+3. WHEN GitHub で表示 THEN claude-code-orchestra 固有の内容が含まれない
+
+### 4. Skill アップデート機構
+
+**User Story:** パッケージ更新後も、bundled skill の改善がユーザーに届いてほしい。ただしユーザーがカスタマイズした skill は上書きしたくない。
+
+- FR-12: SKILL.md frontmatter に `version` フィールド（semver 形式）を追加
+- FR-13: `_copy_skills_template()` は bundled skill の `version` とコピー済み skill の `version` を比較し、bundled が新しければ更新する
+- FR-14: ユーザーがスキルを手動編集している場合（ファイルハッシュが bundled 元と異なる場合）は自動更新をスキップし、warning ログを出力する
+- FR-15: スキップ時、bundled の新バージョンを `.claude/skills/<name>/.bundled-update` に書き出し、ユーザーが diff で差分確認・手動マージできるようにする
+- FR-16: 初回コピー時（dest が存在しない場合）の動作は従来通り
+
+#### Acceptance Criteria
+
+1. WHEN bundled skill の version が "1.1.0" でコピー済みが "1.0.0"（未編集）THEN skill が更新される
+2. WHEN bundled skill の version が "1.1.0" でコピー済みが "1.0.0"（ユーザー編集済み）THEN 自動更新はスキップされ、warning ログが出力され、`.bundled-update` に新バージョンが書き出される
+3. WHEN コピー済み skill が存在しない THEN 従来通り新規コピーされる
+4. WHEN bundled skill と コピー済み skill が同じ version THEN 何もしない
+
+### 5. 配布検証
+
+**User Story:** パッケージメンテナとして、wheel に必要な artifact が全て入っていることを確認したい。
+
+- FR-17: `uv build` の wheel に `insight_blueprint/_skills/` が含まれる
+- FR-18: `uv build` の wheel に `insight_blueprint/static/` が含まれる
+- FR-19: `_copy_skills_template()` を `_skills/` ディレクトリの自動検出に変更（hardcoded list 廃止）
+- FR-20: 手動リリース手順書を作成（version bump → build → verify → ローカルテスト → upload）
+- FR-21: ローカル wheel からのインストール + E2E 動作確認手順を含める（`pip install dist/*.whl` でスキルコピー・WebUI 起動を検証）
+
+#### Acceptance Criteria
+
+1. WHEN `uv build` THEN `unzip -l dist/*.whl | grep _skills` で全 SKILL.md が表示される
+2. WHEN `uv build` THEN `unzip -l dist/*.whl | grep static` で frontend assets が表示される
+3. WHEN 新 skill を `_skills/` に追加 THEN コード変更なしで `_copy_skills_template()` がコピーする
+4. WHEN ローカル wheel をインストール THEN `insight-blueprint --project /tmp/test` でスキルコピー・WebUI 起動が動作する
+
+> **Note:** 実際の PyPI publish はチームによる使用感確認後に手動実行する。SPEC-5 の検証基準はローカル wheel での動作確認まで。
+
+## 非機能要件
+
+### Code Architecture and Modularity
+- skill 変更は `_skills/` 内に閉じる。メタデータ変更は `pyproject.toml` + `LICENSE` に閉じる
+- `_copy_skills_template()` は `importlib.resources` のディレクトリ走査で自動検出。hardcoded list 不要
+- SPEC-5 で新しい runtime 依存は追加しない
+- skill コピーの contract: 初回は新規コピー、以降は version 比較で更新。ユーザーカスタマイズ済みは自動更新スキップ + 通知 + `.bundled-update` 書き出し
+
+### Performance
+- NFR-1: `_copy_skills_template()` は 10 skills まで 500ms 以内
+- NFR-2: skill 自動検出が `init_project()` に体感できる遅延を加えない
+
+### Security
+- NFR-3: README, SKILL.md, `pyproject.toml` に secret・API key を含めない
+- NFR-4: LICENSE は標準 MIT テキスト（正しい copyright holder と年）
+
+### Reliability
+- NFR-5: `_skills/` に subdirectory が0個でもエラーにならない
+- NFR-6: `static/` が空でも wheel build が成功する
+
+### Usability
+- NFR-7: README は Claude Code や MCP の事前知識なしでも理解できる
+- NFR-8: リリース手順書は PyPI 初心者でも追える
+
+## Out of Scope
+
+- 新スキル作成（review-workflow, data-explorer）
+- CI/CD（GitHub Actions での自動 PyPI publish）
+- バージョン自動バンプ・changelog 生成
+- TestPyPI ステージング
+- 実際の PyPI publish（チーム使用感確認後に手動実行。手順書は SPEC-5 で提供）

--- a/.spec-workflow/specs/skills-distribution/tasks.md
+++ b/.spec-workflow/specs/skills-distribution/tasks.md
@@ -1,0 +1,217 @@
+# Tasks — SPEC-5: skills-distribution
+
+## Phase 1: 静的ファイル（並列実行可）
+
+- [x] 1.1 SKILL.md バイリンガル化 + version 追加
+  - File: `src/insight_blueprint/_skills/analysis-design/SKILL.md`, `src/insight_blueprint/_skills/catalog-register/SKILL.md`
+  - 全 SKILL.md の YAML frontmatter に `version: "1.0.0"` を追加
+  - `description` フィールドに英語説明 + 日本語トリガーフレーズを併記
+  - `## Language Rules` セクションを追加（CLAUDE.md 委譲ルール）
+  - body（workflow, rules 等）は英語のまま維持
+  - Purpose: Claude Code が日英どちらのトリガーでもスキルを発見できるようにする
+  - _Leverage: `.claude/rules/skill-format.md` の YAML frontmatter スキーマ_
+  - _Requirements: FR-1, FR-2, FR-3, FR-4, FR-12_
+  - **完了基準:**
+    - 全 SKILL.md に `name`, `version`, `description`, `disable-model-invocation` が存在する
+    - `description` に英語と日本語の両方のトリガーフレーズがある
+    - `## Language Rules` セクションが存在し、CLAUDE.md 委譲ルールを記載している
+    - body 部分が英語で記述されている
+  - **確認手順:**
+    - `grep -l "^version:" src/insight_blueprint/_skills/*/SKILL.md` で全 SKILL.md がヒットすること
+    - 各 SKILL.md の `description` に日本語文字列が含まれること（目視）
+    - `grep -l "Language Rules" src/insight_blueprint/_skills/*/SKILL.md` で全 SKILL.md がヒットすること
+  - _Prompt: Role: Technical writer specializing in Claude Code skill definitions | Task: Add version field and bilingual description to all SKILL.md files under _skills/, following skill-format.md schema. Add Language Rules section delegating to CLAUDE.md. Keep body in English | Restrictions: Do not change existing workflow logic, maintain skill-format.md compliance, version must be semver "1.0.0" | Success: All SKILL.md files have version, bilingual description, Language Rules section, and pass structure validation_
+
+- [x] 1.2 PyPI メタデータ + LICENSE
+  - File: `pyproject.toml`, `LICENSE`
+  - `pyproject.toml` に `license`, `authors`, `classifiers`, `urls` を追加
+  - リポジトリ root に MIT LICENSE ファイルを新規作成
+  - classifiers: Development Status, License (MIT), Python 3.11+, Topic, Framework
+  - urls: Homepage, Repository, Bug Tracker
+  - Purpose: PyPI ページで license・author・分類が正しく表示されるようにする
+  - _Leverage: 既存 `pyproject.toml` 構造_
+  - _Requirements: FR-5, FR-6, FR-7, FR-8, NFR-4_
+  - **完了基準:**
+    - `pyproject.toml` に `license`, `authors`, `classifiers`, `urls` セクションが存在する
+    - `LICENSE` ファイルが MIT テンプレートで、正しい copyright holder と年（2026）を含む
+    - `uv build` が成功する
+  - **確認手順:**
+    - `grep "license" pyproject.toml` で設定が見つかること
+    - `cat LICENSE | head -3` で MIT と copyright 行を確認
+    - `uv build && unzip -p dist/*.whl '*/METADATA' | grep -E '(License|Classifier|Project-URL)'` でメタデータを確認
+  - _Prompt: Role: Python packaging specialist | Task: Add PyPI metadata (license, authors, classifiers, urls) to pyproject.toml and create MIT LICENSE file at repo root | Restrictions: Do not change build backend or existing dependencies, use standard MIT text, copyright year 2026 | Success: uv build succeeds, wheel METADATA contains license, classifiers (Dev Status, MIT, Python 3.11+), and project URLs_
+
+- [x] 1.3 README.md 整備
+  - File: `README.md`
+  - 概要、インストール（`uvx` / `uv tool install`）、Quick Start、機能一覧、開発セットアップを記載
+  - claude-code-orchestra 固有コンテンツ（Codex CLI, Gemini CLI, spec-workflow-mcp 等）を削除
+  - `pyproject.toml` の `readme = "README.md"` は設定済み
+  - Purpose: PyPI / GitHub 訪問者が insight-blueprint の概要・使い方をすぐ理解できるようにする
+  - _Leverage: 既存 README.md_
+  - _Requirements: FR-9, FR-10, FR-11, NFR-7_
+  - **完了基準:**
+    - 最初の3セクションで「何か・インストール・使い方」が分かる
+    - Codex CLI, Gemini CLI, spec-workflow-mcp への言及がない
+    - MCP や Claude Code の事前知識なしでも理解できる
+  - **確認手順:**
+    - `head -50 README.md` で概要・インストール・Quick Start が含まれることを確認
+    - `grep -i -E "(codex|gemini|spec-workflow|orchestra)" README.md` がヒットしないこと
+    - 目視で MCP 未経験者にも通じる記述かを確認
+  - _Prompt: Role: Technical writer for open-source Python tools | Task: Rewrite README.md with overview, installation (uvx/uv tool install), Quick Start, feature list (MCP tools, WebUI, Skills), and dev setup. Remove claude-code-orchestra specific content | Restrictions: No mention of Codex CLI, Gemini CLI, spec-workflow-mcp. Must be understandable without MCP/Claude Code prior knowledge. Keep concise | Success: First 3 sections answer what/install/usage, no orchestra references, readable by newcomers_
+
+## Phase 2: Skill Update Engine（TDD、順序依存あり）
+
+- [x] 2.1 `_discover_bundled_skills()` + `_get_skill_version()`
+  - File: `src/insight_blueprint/storage/project.py`, `tests/test_skill_update.py`
+  - `_discover_bundled_skills()`: `importlib.resources.files` で `_skills/` を走査し、`SKILL.md` を含むディレクトリ名を返す
+  - `_get_skill_version()`: SKILL.md の YAML frontmatter から `version` を読み取る。パースエラー時は `None` + warning
+  - Red-Green-Refactor: テスト U1〜U9 を先に書き、実装で Green にする
+  - Purpose: hardcoded list を廃止し、新スキル追加時にコード変更不要にする
+  - _Leverage: 既存 `importlib.resources.files("insight_blueprint")` パターン_
+  - _Requirements: FR-19, FR-12, NFR-5_
+  - **完了基準:**
+    - `_discover_bundled_skills()` が `_skills/` 配下を自動検出し、`SKILL.md` なしディレクトリを除外する
+    - `_get_skill_version()` が正常 version / version なし / 不正 frontmatter / 不正 semver の4パターンを処理する
+    - テスト U1〜U9 が全て Green
+  - **確認手順:**
+    - `uv run pytest tests/test_skill_update.py -k "discover or get_skill_version" -v` で U1〜U9 全通過
+    - `uv run pytest tests/test_skill_update.py -v --tb=short` でエラーなし
+  - _Prompt: Role: Python developer specializing in importlib.resources and YAML parsing | Task: Implement _discover_bundled_skills() using Traversable API to auto-detect skills, and _get_skill_version() to parse SKILL.md frontmatter version field. Write tests U1-U9 first (TDD). | Restrictions: No shutil.copytree(str(src)), use Traversable API only. No new dependencies for YAML parsing (string-based frontmatter parse). Return None on any parse error with warning log | Success: Tests U1-U9 pass, hardcoded skill list removed, handles all error cases gracefully_
+
+- [x] 2.2 `_hash_skill_directory()`
+  - File: `src/insight_blueprint/storage/project.py`, `tests/test_skill_update.py`
+  - ディレクトリ全体の SHA-256 hash を計算。ファイルパス（相対）+ 内容を sorted 順で hash
+  - `exclude_managed=True` で `.insight-blueprint-state.json`, `.bundled-update.json`, `.bundled-update/` を除外
+  - 行末を LF に正規化してから hash（CRLF 混在環境対応）
+  - Red-Green-Refactor: テスト U10〜U15 を先に書く
+  - Purpose: ユーザーカスタマイズの検出に使う hash 基盤
+  - _Requirements: FR-14_
+  - **完了基準:**
+    - 同一内容で決定的な hash を返す
+    - managed files が除外される
+    - LF/CRLF 混在で同じ hash を返す
+    - サブディレクトリ内のファイルも hash 対象に含む
+    - テスト U10〜U15 が全て Green
+  - **確認手順:**
+    - `uv run pytest tests/test_skill_update.py -k "hash" -v` で U10〜U15 全通過
+  - _Prompt: Role: Python developer with expertise in hashlib and filesystem operations | Task: Implement _hash_skill_directory() computing SHA-256 over sorted (relative_path, normalized_content) pairs. Support exclude_managed flag. Normalize line endings to LF before hashing. Write tests U10-U15 first (TDD) | Restrictions: Use hashlib.sha256, sort by relative path for determinism, normalize \r\n to \n, exclude .insight-blueprint-state.json and .bundled-update.json and .bundled-update/ when exclude_managed=True | Success: Tests U10-U15 pass, hash is deterministic and correctly excludes managed files_
+
+- [x] 2.3 `_load_skill_state()` / `_save_skill_state()`
+  - File: `src/insight_blueprint/storage/project.py`, `tests/test_skill_update.py`
+  - `.insight-blueprint-state.json` の読み書き。欠損時は空 dict、不正 JSON 時も空 dict + warning
+  - Red-Green-Refactor: テスト U16〜U19 を先に書く
+  - Purpose: インストール済みスキルの version と hash を永続化し、次回更新判定に使う
+  - _Requirements: Design: Data Models_
+  - **完了基準:**
+    - save → load のラウンドトリップで全フィールドが一致する
+    - state ファイル欠損・不正 JSON でクラッシュしない
+    - テスト U16〜U19 が全て Green
+  - **確認手順:**
+    - `uv run pytest tests/test_skill_update.py -k "state" -v` で U16〜U19 全通過
+  - _Prompt: Role: Python developer | Task: Implement _load_skill_state() and _save_skill_state() for .insight-blueprint-state.json read/write. Return empty dict on missing or corrupt file with warning log. Write tests U16-U19 first (TDD) | Restrictions: Use json module, no new dependencies. Warning log on errors, never raise. Include installed_version, installed_bundled_hash, updated_at fields | Success: Tests U16-U19 pass, graceful degradation on all error cases_
+
+- [x] 2.4 `_copy_skill_tree()`
+  - File: `src/insight_blueprint/storage/project.py`, `tests/test_skill_update.py`
+  - `importlib.resources` の `Traversable` API で再帰コピー。`shutil.copytree(str(src))` は使わない
+  - 更新時は既存ディレクトリを `.backup` にリネーム → 新規コピー → 成功時 `.backup` 削除、失敗時リストア
+  - Red-Green-Refactor: テスト U20〜U23 を先に書く
+  - Purpose: importer 依存を避けた堅牢なスキルコピー。部分失敗時にも元の状態を維持
+  - _Leverage: 既存 `importlib.resources.files()` パターン_
+  - _Requirements: FR-16, Error #8_
+  - **完了基準:**
+    - Traversable からファイル・サブディレクトリを再帰コピーできる
+    - 更新時に atomic backup/restore が機能する
+    - テスト U20〜U23 が全て Green
+  - **確認手順:**
+    - `uv run pytest tests/test_skill_update.py -k "copy_skill_tree" -v` で U20〜U23 全通過
+  - _Prompt: Role: Python developer with importlib.resources expertise | Task: Implement _copy_skill_tree(src: Traversable, dest: Path) that recursively copies files from Traversable to dest. On update (dest exists), rename dest to .backup first, copy new, delete .backup on success, restore on failure. Write tests U20-U23 first (TDD) | Restrictions: Do NOT use shutil.copytree(str(src)) — iterate Traversable directly. Atomic backup/restore for update case | Success: Tests U20-U23 pass, Traversable iteration works, atomic restore on failure_
+
+- [x] 2.5 `_write_bundled_update()`
+  - File: `src/insight_blueprint/storage/project.py`, `tests/test_skill_update.py`
+  - `.bundled-update.json` に version 情報 + diff コマンドを書き出し、`.bundled-update/` に新バージョンのスキルファイル一式をコピー
+  - 書き込み失敗時は warning ログのみ（処理全体は継続）
+  - Red-Green-Refactor: テスト U24〜U26 を先に書く
+  - Purpose: ユーザーがカスタマイズ済みスキルと新バージョンの差分を確認・マージできるようにする
+  - _Requirements: FR-15, Error #5_
+  - **完了基準:**
+    - `.bundled-update.json` に `from_version`, `to_version`, `created_at`, `message` が含まれる
+    - `.bundled-update/` に新バージョンのスキルファイルがコピーされる
+    - 書き込み失敗時にクラッシュしない
+    - テスト U24〜U26 が全て Green
+  - **確認手順:**
+    - `uv run pytest tests/test_skill_update.py -k "bundled_update" -v` で U24〜U26 全通過
+  - _Prompt: Role: Python developer | Task: Implement _write_bundled_update() that writes .bundled-update.json with version info and diff command, and copies new skill files to .bundled-update/ directory. Catch permission errors gracefully. Write tests U24-U26 first (TDD) | Restrictions: Catch all write errors, log warning, never crash. Include from_version, to_version, created_at, message fields in JSON | Success: Tests U24-U26 pass, notification file and directory created correctly, permission errors handled_
+
+- [x] 2.6 `_copy_skills_template()` 判定ロジック統合
+  - File: `src/insight_blueprint/storage/project.py`, `tests/test_skill_update.py`
+  - 既存の `_copy_skills_template()` を version-aware な判定ロジックに置き換え
+  - hardcoded list (`skills_to_copy`) を `_discover_bundled_skills()` に置換
+  - 判定フロー: 初回コピー / 同 version skip / upgrade 未編集 / upgrade 編集済み / downgrade skip / legacy (version なし)
+  - Red-Green-Refactor: テスト U27〜U33 を先に書く
+  - Purpose: 2.1〜2.5 のヘルパーを統合し、Design の Update Decision Logic を実装する
+  - _Leverage: Task 2.1〜2.5 の全ヘルパー関数_
+  - _Requirements: FR-13, FR-14, FR-16, FR-19_
+  - **完了基準:**
+    - hardcoded list が削除されている
+    - 7つの判定ケース（U27〜U33）が全て正しく動作する
+    - 既存の `_copy_skills_template()` signature（引数・戻り値）が変更されていない
+    - テスト U27〜U33 が全て Green
+  - **確認手順:**
+    - `grep "skills_to_copy" src/insight_blueprint/storage/project.py` がヒットしないこと
+    - `uv run pytest tests/test_skill_update.py -k "copy_skills_template" -v` で U27〜U33 全通過
+    - `uv run pytest tests/test_skill_update.py -v` で全 unit test 通過
+  - _Prompt: Role: Python developer | Task: Refactor _copy_skills_template() to use _discover_bundled_skills() instead of hardcoded list, and implement version-aware update decision logic using helpers from tasks 2.1-2.5. Write tests U27-U33 first (TDD) covering all 7 decision cases | Restrictions: Keep _copy_skills_template(project_path: Path) -> None signature unchanged. Use packaging.version.Version for semver comparison. All errors handled gracefully with fallback behavior | Success: Tests U27-U33 pass, hardcoded list removed, all 7 decision paths covered and tested_
+
+## Phase 3: 統合テスト + 検証
+
+- [x] 3.1 Integration tests
+  - File: `tests/test_skill_integration.py`
+  - `init_project()` 経由のライフサイクルテスト（I1〜I6）
+  - I5: 10 skills で 500ms 以内のパフォーマンステスト
+  - I6: 既存機能（`.insight/` ディレクトリ、`.mcp.json`）のリグレッションチェック
+  - Purpose: ヘルパー単体ではなく、公開 API としての `init_project()` の振る舞いを検証する
+  - _Leverage: 既存 `conftest.py` の `tmp_project` fixture_
+  - _Requirements: FR-13, FR-14, FR-15, FR-17, FR-19, NFR-1, NFR-2_
+  - **完了基準:**
+    - テスト I1〜I6 が全て Green
+    - 既存テスト（`uv run pytest` 全体）にリグレッションがない
+  - **確認手順:**
+    - `uv run pytest tests/test_skill_integration.py -v` で I1〜I6 全通過
+    - `uv run pytest -v` で全テスト通過（既存 + 新規）
+  - _Prompt: Role: Python test engineer | Task: Write integration tests I1-I6 for init_project() lifecycle: fresh copy, idempotent no-change, customization preservation, unmodified update, performance (10 skills < 500ms), regression check (dirs + .mcp.json) | Restrictions: Use tmp_path fixture, mock importlib.resources for controlled skill sets, measure wall-clock time for I5 | Success: All 6 integration tests pass, full test suite passes without regression_
+
+- [x] 3.2 Build validation
+  - File: なし（コマンド実行のみ）
+  - `uv build` を実行し、wheel の内容を検証（B1〜B7）
+  - SKILL.md の構造検証（B8〜B11）
+  - Purpose: wheel に必要な artifact が全て含まれ、メタデータが正しいことを確認する
+  - _Requirements: FR-5, FR-6, FR-7, FR-8, FR-10, FR-17, FR-18_
+  - **完了基準:**
+    - `uv build` が成功する
+    - wheel に `_skills/`, `static/`, `LICENSE` が含まれる
+    - METADATA に license, classifiers, project URLs が含まれる
+    - 全 SKILL.md が `name`, `version`, `description` を持つ
+  - **確認手順:**
+    - `uv build` が exit 0
+    - `unzip -l dist/*.whl | grep _skills/` で全スキルの SKILL.md が表示
+    - `unzip -l dist/*.whl | grep static/` で frontend assets が表示
+    - `unzip -l dist/*.whl | grep LICENSE` で LICENSE が表示
+    - `unzip -p dist/*.whl '*/METADATA' | grep -E '(License|Classifier|Project-URL)'` でメタデータ確認
+  - _Prompt: Role: Python packaging validator | Task: Run uv build and verify wheel contents match B1-B11 checks. Inspect METADATA for license, classifiers, URLs. Parse all _skills/*/SKILL.md for required frontmatter fields | Restrictions: Do not modify any files. Read-only validation only | Success: All B1-B11 checks pass_
+
+- [x] 3.3 Release procedure doc
+  - File: `docs/RELEASE.md`
+  - version bump → build → verify → ローカルテスト → upload の手順書を作成
+  - ローカル wheel インストール + E2E 動作確認手順を含める
+  - PyPI 初心者でも追える記述レベル
+  - Purpose: チーム確認後の PyPI publish を安全に実行できるようにする
+  - _Requirements: FR-20, FR-21, NFR-8_
+  - **完了基準:**
+    - `docs/RELEASE.md` に version bump, build, verify, local test, upload の全ステップがある
+    - ローカル wheel からのインストール + スキルコピー + WebUI 起動の確認手順が含まれる
+    - 各ステップにコマンド例がある
+  - **確認手順:**
+    - `cat docs/RELEASE.md` で全ステップの存在を確認
+    - `grep -c "```" docs/RELEASE.md` でコマンド例が5つ以上あること
+    - 目視で PyPI 初心者が追えるかを確認
+  - _Prompt: Role: Technical writer for Python release processes | Task: Create docs/RELEASE.md with step-by-step release procedure: version bump, uv build, wheel inspection, local install test (skills copy + WebUI launch), twine upload. Include concrete commands at each step | Restrictions: Target audience is PyPI beginners. No assumed knowledge of twine/PyPI workflows. Include local wheel verification before any upload step | Success: Complete procedure from version bump to upload, each step has runnable commands, readable by PyPI newcomers_

--- a/.spec-workflow/specs/skills-distribution/test-design.md
+++ b/.spec-workflow/specs/skills-distribution/test-design.md
@@ -1,0 +1,305 @@
+# SPEC-5: skills-distribution — Test Design
+
+> **Spec ID**: SPEC-5
+> **Status**: draft
+> **Created**: 2026-02-28
+> **Depends On**: None (standalone spec)
+
+---
+
+## Test Architecture
+
+### Test Scope Decision
+
+SPEC-5 has three distinct areas:
+1. **Skill Update Engine** (`storage/project.py`) — Python logic with version comparison, hash calculation, file copy. High test value.
+2. **Bundled Skills** (`_skills/*.md`) — Static text files. Verified by linting and structure checks.
+3. **Package Metadata** (`pyproject.toml`, `LICENSE`, `README.md`) — Static files. Verified by build validation.
+
+**Automated testing focuses on area 1** — the skill update engine. Areas 2 and 3 are verified through build validation and manual checklist.
+
+### Test Pyramid
+
+```
+          ┌──────────────────┐
+          │  Manual Checklist  │  ← wheel contents, README, SKILL.md review
+          ├──────────────────┤
+        ┌─┤  Build Validation ├─┐  ← uv build, wheel inspection
+        │ ├──────────────────┤ │
+      ┌─┴─┤ Integration Tests├─┴─┐  ← init_project() E2E scenarios
+      │   ├──────────────────┤   │
+  ┌───┴───┤   Unit Tests     ├───┴───┐  ← Per-function tests for update engine
+  └───────┴──────────────────┴───────┘
+         +
+  ┌──────────────────────────┐
+  │  Existing Tests (341+)    │  ← Regression: no changes to existing modules
+  └──────────────────────────┘
+```
+
+### Test File Location
+
+```
+tests/
+├── conftest.py                  # Add: bundled_skills fixture, mock_skill_dir
+├── test_skill_update.py         # NEW: Unit tests for update engine functions
+├── test_skill_integration.py    # NEW: Integration tests for init_project() flow
+└── test_storage.py              # EXISTING: Ensure no regression
+```
+
+---
+
+## Unit Tests — Skill Update Engine
+
+### Test File: `tests/test_skill_update.py`
+
+All helper functions in `storage/project.py` are tested individually.
+
+### 1. `_discover_bundled_skills()`
+
+| # | Test Name | Setup | Expected | Req |
+|---|-----------|-------|----------|-----|
+| U1 | discover_with_multiple_skills | `_skills/` with 2 dirs each containing `SKILL.md` | Returns `["analysis-design", "catalog-register"]` (sorted) | FR-19 |
+| U2 | discover_empty_skills_dir | `_skills/` exists but empty | Returns `[]` | NFR-5 |
+| U3 | discover_skips_dir_without_skill_md | `_skills/foo/` with no `SKILL.md` | Excluded from result | FR-19 |
+| U4 | discover_skips_files | `_skills/README.md` (file, not dir) | Excluded from result | FR-19 |
+
+### 2. `_get_skill_version()`
+
+| # | Test Name | Setup | Expected | Req |
+|---|-----------|-------|----------|-----|
+| U5 | version_valid_semver | SKILL.md with `version: "1.2.3"` | Returns `"1.2.3"` | FR-12 |
+| U6 | version_missing_field | SKILL.md without `version` | Returns `None` | Error #2 |
+| U7 | version_invalid_frontmatter | SKILL.md with broken `---` delimiters | Returns `None` + warning log | Error #4 |
+| U8 | version_invalid_semver | SKILL.md with `version: "latest"` | Returns `None` + warning log | Error #6 |
+| U9 | version_no_quotes | SKILL.md with `version: 1.0.0` (YAML parses as float) | Returns `"1.0.0"` (coerced to string) | Robustness |
+
+### 3. `_hash_skill_directory()`
+
+| # | Test Name | Setup | Expected | Req |
+|---|-----------|-------|----------|-----|
+| U10 | hash_deterministic | Same directory contents | Same hash on repeated calls | FR-14 |
+| U11 | hash_changes_on_edit | Modify SKILL.md content | Hash changes | FR-14 |
+| U12 | hash_excludes_managed_files | Add `.insight-blueprint-state.json` | Hash unchanged with `exclude_managed=True` | Design: Data Models |
+| U13 | hash_excludes_bundled_update | Add `.bundled-update.json` and `.bundled-update/` dir | Hash unchanged with `exclude_managed=True` | Design: Data Models |
+| U14 | hash_normalizes_line_endings | Same content with LF vs CRLF | Same hash | Design: Interfaces |
+| U15 | hash_includes_subdirectory | `references/foo.md` added | Hash changes | Design: Architecture |
+
+### 4. `_load_skill_state()` / `_save_skill_state()`
+
+| # | Test Name | Setup | Expected | Req |
+|---|-----------|-------|----------|-----|
+| U16 | save_and_load_roundtrip | Save state → load state | All fields match | Design: Data Models |
+| U17 | load_missing_state | No `.insight-blueprint-state.json` | Returns empty dict | Error #3 |
+| U18 | load_invalid_json | Corrupt JSON in state file | Returns empty dict + warning log | Robustness |
+| U19 | save_creates_parent_dirs | `dest/` exists, state file absent | File created successfully | Robustness |
+
+### 5. `_copy_skill_tree()`
+
+| # | Test Name | Setup | Expected | Req |
+|---|-----------|-------|----------|-----|
+| U20 | copy_single_file | Traversable with `SKILL.md` only | `dest/SKILL.md` exists with same content | FR-16 |
+| U21 | copy_with_subdirectory | Traversable with `SKILL.md` + `references/foo.md` | Both files copied | FR-16 |
+| U22 | copy_overwrites_existing | Pre-existing `dest/SKILL.md` | Overwritten with new content | FR-13 |
+| U23 | copy_atomic_backup_restore | Simulate write failure mid-copy | Original files restored from `.backup` | Error #8 |
+
+### 6. `_write_bundled_update()`
+
+| # | Test Name | Setup | Expected | Req |
+|---|-----------|-------|----------|-----|
+| U24 | write_creates_json_and_dir | Normal call | `.bundled-update.json` + `.bundled-update/` dir with skill files | FR-15 |
+| U25 | write_includes_diff_message | versions "1.0.0" → "1.1.0" | JSON contains `from_version`, `to_version`, diff command | FR-15 |
+| U26 | write_permission_error | Read-only `dest_dir` | Exception caught, warning log, no crash | Error #5 |
+
+### 7. `_copy_skills_template()` — Decision Logic
+
+| # | Test Name | Setup | Expected | Req |
+|---|-----------|-------|----------|-----|
+| U27 | case1_fresh_copy | dest does not exist | Skill copied + state saved | FR-16, AC-3 |
+| U28 | case2_same_version_skip | bundled v1.0.0, installed v1.0.0 | No copy, no change | AC-4 |
+| U29 | case3_upgrade_unmodified | bundled v1.1.0, installed v1.0.0, hash matches | Skill updated + state updated | AC-1 |
+| U30 | case4_upgrade_customized | bundled v1.1.0, installed v1.0.0, hash differs | Skip + warning + `.bundled-update` written | AC-2 |
+| U31 | case5_downgrade_skip | bundled v0.9.0, installed v1.0.0 | No copy, no change | Error #7 |
+| U32 | case6_no_version_legacy | bundled has no version, dest exists | Skip (legacy behavior) | Error #2 |
+| U33 | case7_no_version_fresh | bundled has no version, dest absent | Fresh copy (legacy behavior) | FR-16 |
+
+---
+
+## Integration Tests — init_project() Flow
+
+### Test File: `tests/test_skill_integration.py`
+
+Full lifecycle tests through the public `init_project()` interface.
+
+| # | Test Name | Steps | Expected | Req |
+|---|-----------|-------|----------|-----|
+| I1 | init_copies_all_bundled_skills | `init_project(tmp)` on empty dir | All skills from `_skills/` appear in `.claude/skills/` | FR-17, FR-19 |
+| I2 | init_idempotent_no_change | `init_project(tmp)` twice, no edits between | Second call makes no changes | NFR-2 |
+| I3 | init_respects_customization | `init_project()` → edit SKILL.md → bump bundled version → `init_project()` | Edit preserved, `.bundled-update` written | FR-14, FR-15 |
+| I4 | init_updates_unmodified_skill | `init_project()` → bump bundled version → `init_project()` | Skill updated to new version | FR-13 |
+| I5 | init_performance | `init_project()` with 10 skills | Completes within 500ms | NFR-1 |
+| I6 | init_no_regression_dirs | `init_project(tmp)` | `.insight/` dirs still created, `.mcp.json` still registered | Regression |
+
+---
+
+## Build Validation
+
+### Wheel Contents
+
+| # | Check | Command | Expected | Req |
+|---|-------|---------|----------|-----|
+| B1 | Skills in wheel | `uv build && unzip -l dist/*.whl \| grep _skills` | All `_skills/*/SKILL.md` listed | FR-17 |
+| B2 | Static in wheel | `uv build && unzip -l dist/*.whl \| grep static` | `static/index.html` + `static/assets/` listed | FR-18 |
+| B3 | LICENSE in wheel | `unzip -l dist/*.whl \| grep LICENSE` | `LICENSE` present | FR-6 |
+| B4 | Metadata license | `unzip -p dist/*.whl '*/METADATA' \| grep License` | MIT license listed | FR-5 |
+| B5 | Metadata classifiers | `unzip -p dist/*.whl '*/METADATA' \| grep Classifier` | Development Status, License, Python 3.11+ | FR-7 |
+| B6 | Metadata urls | `unzip -p dist/*.whl '*/METADATA' \| grep Project-URL` | Homepage, Repository, Bug Tracker | FR-8 |
+| B7 | README as description | `unzip -p dist/*.whl '*/METADATA' \| head -50` | Long description from README.md | FR-10 |
+
+### SKILL.md Structure Validation
+
+| # | Check | Command | Expected | Req |
+|---|-------|---------|----------|-----|
+| B8 | Frontmatter fields | Parse all `_skills/*/SKILL.md` | Each has `name`, `version`, `description` | FR-4, FR-12 |
+| B9 | Bilingual description | Grep `description` field | Contains both English and Japanese triggers | FR-2 |
+| B10 | Language Rules section | Grep `## Language Rules` | Present in all SKILL.md | FR-3 |
+| B11 | Body in English | Manual review | Workflow/rules sections in English | FR-1 |
+
+---
+
+## Manual Verification Checklist
+
+### Pre-condition
+
+- `uv build` succeeds
+- Wheel file exists in `dist/`
+
+### Package Metadata
+
+| # | Operation | Steps | Expected | Req |
+|---|-----------|-------|----------|-----|
+| M1 | LICENSE file | `cat LICENSE` | MIT license with correct copyright holder and year | FR-6, NFR-4 |
+| M2 | README readability | Read first 3 sections of README.md | Purpose, install, usage are clear without prior knowledge | FR-9, NFR-7 |
+| M3 | No orchestra content | Grep README for `Codex CLI`, `Gemini CLI`, `spec-workflow` | Not found | FR-11 |
+| M4 | No secrets | Grep `pyproject.toml`, README, SKILL.md for patterns like `sk-`, `api_key` | Not found | NFR-3 |
+
+### Local Wheel Installation
+
+| # | Operation | Steps | Expected | Req |
+|---|-----------|-------|----------|-----|
+| M5 | Wheel install | `pip install dist/*.whl` in clean venv | Install succeeds | FR-21 |
+| M6 | Skill copy | `insight-blueprint --project /tmp/test` | `.claude/skills/` populated with all bundled skills | FR-17, FR-21 |
+| M7 | WebUI launch | Same command as M6 | WebUI accessible on expected port | FR-21 |
+| M8 | Skill bilingual trigger | Invoke skill via English phrase, then Japanese phrase | Both discovered | AC 1.1-1.4 |
+
+### Release Procedure
+
+| # | Operation | Steps | Expected | Req |
+|---|-----------|-------|----------|-----|
+| M9 | Release doc exists | `cat docs/RELEASE.md` | Step-by-step procedure present | FR-20 |
+| M10 | Release doc completeness | Read RELEASE.md | Covers version bump, build, verify, local test, upload | FR-20, NFR-8 |
+
+---
+
+## Acceptance Criteria Traceability
+
+### Requirements → Test Mapping
+
+| AC | Test Type | Verification |
+|----|-----------|-------------|
+| AC 1.1 (EN trigger discovery) | Manual M8 | English phrase triggers skill |
+| AC 1.2 (JP trigger discovery) | Manual M8 | Japanese phrase triggers skill |
+| AC 1.3 (EN trigger catalog) | Manual M8 | English phrase triggers skill |
+| AC 1.4 (JP trigger catalog) | Manual M8 | Japanese phrase triggers skill |
+| AC 1.5 (default JP response) | Manual M8 | Responds in Japanese without CLAUDE.md setting |
+| AC 1.6 (EN response override) | Manual M8 | Responds in English when configured |
+| AC 2.1 (wheel metadata) | Build B4, B5 | License, classifiers present |
+| AC 2.2 (PyPI display) | Manual (post-publish) | Out of SPEC-5 scope |
+| AC 3.1 (README clarity) | Manual M2 | First 3 sections clear |
+| AC 3.2 (wheel long_desc) | Build B7 | README.md in METADATA |
+| AC 3.3 (no orchestra) | Manual M3 | No claude-code-orchestra content |
+| AC 4.1 (version upgrade unmodified) | **Unit U29** + **Integration I4** | Auto-update works |
+| AC 4.2 (version upgrade customized) | **Unit U30** + **Integration I3** | Skip + warning + `.bundled-update` |
+| AC 4.3 (fresh copy) | **Unit U27** + **Integration I1** | New skill copied |
+| AC 4.4 (same version skip) | **Unit U28** + **Integration I2** | No change |
+| AC 5.1 (skills in wheel) | **Build B1** | `_skills/` in wheel |
+| AC 5.2 (static in wheel) | **Build B2** | `static/` in wheel |
+| AC 5.3 (auto-detect new skills) | **Unit U1** + **Integration I1** | No hardcoded list |
+| AC 5.4 (local wheel E2E) | Manual M5, M6, M7 | Install → skills copy → WebUI |
+| NFR-1 (performance) | **Integration I5** | 10 skills in 500ms |
+| NFR-2 (no perceptible delay) | **Integration I2** | Idempotent call is fast |
+| NFR-3 (no secrets) | Manual M4 | No secret patterns |
+| NFR-4 (MIT license) | Manual M1 | Standard MIT text |
+| NFR-5 (empty skills dir) | **Unit U2** | Returns empty list |
+| NFR-6 (empty static dir) | **Build B2** | Build succeeds |
+| NFR-7 (README readability) | Manual M2 | Understandable |
+| NFR-8 (release doc clarity) | Manual M10 | PyPI beginner can follow |
+
+---
+
+## Regression Strategy
+
+### Existing Tests Impact
+
+SPEC-5 modifies only `storage/project.py` (one function: `_copy_skills_template()`). Other modules are untouched.
+
+**Verification**: After SPEC-5 implementation, run `uv run pytest` and confirm all existing tests pass.
+
+### Specific Regression Risks
+
+| Risk | Mitigation | Verification |
+|------|-----------|-------------|
+| `init_project()` breaks existing behavior | Integration I6 explicitly checks dirs + `.mcp.json` | Unit + Integration tests |
+| New `packaging` import causes import failure | `packaging` is always available via pip/setuptools | Unit test import check |
+| `_copy_skills_template()` signature change | Signature unchanged (only internal logic changes) | Existing `tmp_project` fixture continues to work |
+| Hardcoded skill list removal | `_discover_bundled_skills()` replaces hardcoded list | Unit U1-U4 |
+
+---
+
+## Security Considerations
+
+| Concern | Mitigation | Verification |
+|---------|-----------|-------------|
+| Path traversal in skill names | `_discover_bundled_skills()` only reads `_skills/` subdirs via `importlib.resources` | Unit U1-U4 |
+| Arbitrary file write via `.bundled-update` | Write only to `.claude/skills/<name>/` under project path | Unit U24-U26 |
+| Secret leak in SKILL.md/README | No API keys, passwords, or secrets in distributed files | Manual M4 |
+| LICENSE correctness | MIT text verified manually | Manual M1 |
+
+---
+
+## Fixtures and Test Utilities
+
+### New Fixtures (in `conftest.py` or `test_skill_update.py`)
+
+```python
+@pytest.fixture
+def skill_dir(tmp_path: Path) -> Path:
+    """Create a minimal skill directory with SKILL.md."""
+    skill = tmp_path / "test-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: test-skill\nversion: \"1.0.0\"\n"
+        "description: Test skill\n---\n# Test Skill\n"
+    )
+    return skill
+
+
+@pytest.fixture
+def bundled_skills_dir(tmp_path: Path) -> Path:
+    """Create a mock _skills/ directory with multiple skills."""
+    skills = tmp_path / "_skills"
+    for name in ["alpha", "beta"]:
+        d = skills / name
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(
+            f"---\nname: {name}\nversion: \"1.0.0\"\n"
+            f"description: {name} skill\n---\n# {name}\n"
+        )
+    return skills
+```
+
+### Mocking Strategy
+
+- `importlib.resources.files()` — Mock with `unittest.mock.patch` to return controlled `Traversable` objects
+- File system — Use `tmp_path` fixture exclusively. No real `_skills/` access in unit tests
+- Time — Freeze `datetime.now()` for `updated_at` assertions
+- Logging — Use `caplog` fixture to assert warning messages


### PR DESCRIPTION
## Summary
- SPEC-1 (core-foundation), SPEC-1a (hypothesis-enrichment), SPEC-2 (data-catalog), SPEC-3 (review-workflow), SPEC-4a (webui-backend), SPEC-4b (webui-frontend), inline-review-comments, skills-distribution の初期仕様書をコミット
- これらはリモートの名前付きspec群（verification-design, knowledge-suggestion, team-server-separation 等）が前提とする上流仕様
- トレーサビリティチェーンの完全性を確保するために追加

## Test plan
- [ ] CIステータスチェック3件がパスすること
- [ ] `.gitignore` により `Implementation Logs/` が含まれていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)