### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insight-blueprint",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Hypothesis-driven data analysis workflow and catalog MCP server",
   "author": { "name": "Eto Yama" },
   "repository": "https://github.com/etoyama/insight-blueprint",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-06
+
 ### Added
 
 - `/batch-analysis` skill for overnight batch execution of queued analysis designs
@@ -16,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Plugin validation CI job (`plugin-validate`)
 - data-lineage Python package prerequisites check
 - Migration guide in README
+- Custom marketplace for plugin distribution
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "insight-blueprint"
-version = "0.4.0"
+version = "0.4.1"
 description = "MCP server for data science analysis design management"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- `pyproject.toml` と `.claude-plugin/plugin.json` のバージョンを 0.4.0 → 0.4.1 に更新
- CHANGELOG.md の Unreleased セクションを 0.4.1 としてリリース
- Plugin marketplace 経由でのバージョン更新を認識させるためのリリース

## Test plan
- [ ] CIステータスチェックがパスすること
- [ ] マージ後に `v0.4.1` タグを作成すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)