### PR TITLE
fix(#82,#81): allow review on revision_requested and warn on missing methodology

### DIFF
--- a/skills/analysis-design/SKILL.md
+++ b/skills/analysis-design/SKILL.md
@@ -87,10 +87,17 @@ Interview the user for required fields:
 | `metrics` | No | List of verification metric dicts (tier: "primary" / "secondary" / "guardrail") | `[{target: "crime_rate_per_100k", tier: "primary", data_source: {crime: "0000010111"}, grouping: [...], filter: "...", aggregation: "mean", comparison: "..."}]` |
 | `explanatory` | No | List of explanatory variable dicts (role: "treatment" / "confounder" / "covariate" / "instrumental" / "mediator") | `[{name: "foreign_ratio", description: "外国人比率", role: "treatment", data_source: "0000010101", time_points: "2012-2022"}]` |
 | `chart` | No | List of visualization definition dicts (intent: "distribution" / "correlation" / "trend" / "comparison") | `[{intent: "correlation", type: "scatter", description: "FP ratio vs crime rate", x: "foreign_ratio", y: "crime_rate"}]` |
-| `methodology` | No | Analysis method and package | `{method: "OLS", package: "statsmodels", reason: "線形回帰で相関を検証"}` |
+| `methodology` | **Yes** | Analysis method and package (must include `method` key) | `{method: "OLS", package: "statsmodels", reason: "線形回帰で相関を検証"}` |
 | `next_action` | No | Branch definition after hypothesis test | `{if_supported: "...", if_rejected: {reason: "...", pivot: "..."}}` |
 
 If the user passed `$ARGUMENTS`, use it as `theme_id` (validate format first).
+
+### Step 2.5: Pre-creation Check
+
+Before calling `create_analysis_design`, verify that `methodology` is NOT null.
+If the interview did not cover methodology, ask now:
+- "What analysis method will you use? (e.g., OLS, t-test, chi-square, DID)"
+- Set `methodology = {method: "<answer>", reason: "<why this method>"}` at minimum.
 
 ### Step 3: Create the Design
 
@@ -99,12 +106,12 @@ create_analysis_design(
     title="<title>",
     hypothesis_statement="<statement>",
     hypothesis_background="<background>",
+    methodology=<dict>,                  # REQUIRED: {method, package?, reason?}
     theme_id="<theme_id or DEFAULT>",
     parent_id=<"FP-H01" or None>,
     metrics=<list[dict] or None>,        # each dict: {target, tier?, data_source?, grouping?, filter?, aggregation?, comparison?}
     explanatory=<list[dict] or None>,    # each dict: {name, description?, role?, data_source?, time_points?}
     chart=<list[dict] or None>,          # each dict: {intent, type?, description?, x?, y?}
-    methodology=<dict or None>,          # {method, package?, reason?}
     next_action=<dict or None>,
 )
 ```
@@ -140,7 +147,7 @@ Only provided fields are updated; all others remain unchanged.
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
 | `list_analysis_designs(status?)` | List existing designs | `status`: in_review \| revision_requested \| analyzing \| supported \| rejected \| inconclusive |
-| `create_analysis_design(...)` | Create new design | `title`, `hypothesis_statement`, `hypothesis_background`, `theme_id?`, `parent_id?`, `metrics?`, `explanatory?`, `chart?`, `methodology?`, `next_action?`, `analysis_intent?` |
+| `create_analysis_design(...)` | Create new design | `title`, `hypothesis_statement`, `hypothesis_background`, **`methodology`**, `theme_id?`, `parent_id?`, `metrics?`, `explanatory?`, `chart?`, `next_action?`, `analysis_intent?` |
 | `update_analysis_design(...)` | Partially update existing design | `design_id`, `title?`, `hypothesis_statement?`, `hypothesis_background?`, `metrics?`, `explanatory?`, `chart?`, `methodology?`, `next_action?`, `analysis_intent?` |
 | `get_analysis_design(design_id)` | Retrieve a specific design | `design_id`: str (e.g., "FP-H01") |
 

--- a/src/insight_blueprint/core/designs.py
+++ b/src/insight_blueprint/core/designs.py
@@ -76,6 +76,8 @@ class DesignService:
         }
         if methodology is not None:
             kwargs["methodology"] = methodology
+        else:
+            logger.warning("create_design called without methodology for '%s'", title)
 
         design = AnalysisDesign(**kwargs)
 

--- a/src/insight_blueprint/core/reviews.py
+++ b/src/insight_blueprint/core/reviews.py
@@ -58,7 +58,14 @@ VALID_TRANSITIONS: dict[DesignStatus, set[DesignStatus]] = {
         DesignStatus.rejected,
         DesignStatus.inconclusive,
     },
-    DesignStatus.revision_requested: {DesignStatus.in_review},
+    DesignStatus.revision_requested: {
+        DesignStatus.in_review,
+        DesignStatus.revision_requested,
+        DesignStatus.analyzing,
+        DesignStatus.supported,
+        DesignStatus.rejected,
+        DesignStatus.inconclusive,
+    },
     DesignStatus.analyzing: {DesignStatus.in_review},
     DesignStatus.supported: set(),
     DesignStatus.rejected: set(),
@@ -96,11 +103,17 @@ def _validate_post_review_status(status: str) -> DesignStatus:
     return target_status
 
 
-def _ensure_in_review(design: AnalysisDesign | None, operation: str) -> None:
-    """Raise ValueError if design is not in in_review status."""
-    if design is not None and design.status != DesignStatus.in_review:
+REVIEWABLE_STATUSES: set[DesignStatus] = {
+    DesignStatus.in_review,
+    DesignStatus.revision_requested,
+}
+
+
+def _ensure_reviewable(design: AnalysisDesign | None, operation: str) -> None:
+    """Raise ValueError if design is not in a reviewable status."""
+    if design is not None and design.status not in REVIEWABLE_STATUSES:
         raise ValueError(
-            f"Design must be in 'in_review' status to {operation}, "
+            f"Design must be in reviewable status to {operation}, "
             f"current status: '{design.status}'"
         )
 
@@ -163,7 +176,8 @@ class ReviewService:
         """Save a review comment and transition the design status.
 
         Returns None if design not found.
-        Raises ValueError if design is not in 'in_review' status
+        Raises ValueError if design is not in reviewable status
+        (in_review or revision_requested)
         or if status is not a valid post-review status.
         """
         _validate_id(design_id, "design_id")
@@ -172,7 +186,7 @@ class ReviewService:
         design = self._design_service.get_design(design_id)
         if design is None:
             return None
-        _ensure_in_review(design, "save review comment")
+        _ensure_reviewable(design, "save review comment")
 
         # Create comment
         comment_id = f"RC-{uuid.uuid4().hex[:8]}"
@@ -207,7 +221,8 @@ class ReviewService:
         """Save a batch of review comments and transition the design status.
 
         Returns None if design not found.
-        Raises ValueError if design is not in 'in_review' status,
+        Raises ValueError if design is not in reviewable status
+        (in_review or revision_requested),
         status is invalid, or target_section is not in ALLOWED_TARGET_SECTIONS.
         """
         _validate_id(design_id, "design_id")
@@ -229,7 +244,7 @@ class ReviewService:
         design = self._design_service.get_design(design_id)
         if design is None:
             return None
-        _ensure_in_review(design, "save review batch")
+        _ensure_reviewable(design, "save review batch")
 
         # Create batch
         batch_id = f"RB-{uuid.uuid4().hex[:8]}"

--- a/src/insight_blueprint/server.py
+++ b/src/insight_blueprint/server.py
@@ -47,6 +47,7 @@ async def create_analysis_design(
     title: str,
     hypothesis_statement: str,
     hypothesis_background: str,
+    methodology: dict | None = None,
     parent_id: str | None = None,
     theme_id: str = "DEFAULT",
     metrics: list[dict] | None = None,
@@ -55,12 +56,15 @@ async def create_analysis_design(
     next_action: dict | None = None,
     referenced_knowledge: dict | None = None,
     analysis_intent: str = "confirmatory",
-    methodology: dict | None = None,
 ) -> dict:
     """Create a new analysis design document.
 
     Creates a YAML file in .insight/designs/ with 'in_review' status.
     theme_id must match [A-Z][A-Z0-9]* pattern (e.g., 'FP', 'TX', 'DEFAULT').
+
+    methodology: Analysis method dict with required 'method' key.
+                 Example: {"method": "OLS", "package": "statsmodels", "reason": "..."}
+                 WARNING: Should rarely be None — methodology is a core design field.
 
     Returns: dict with id, title, status, message
     """
@@ -390,8 +394,9 @@ async def save_review_comment(
 ) -> dict:
     """Save a review comment and transition the design status.
 
-    The design must be in 'in_review' status. Valid post-review statuses:
-    revision_requested, analyzing, supported, rejected, inconclusive.
+    The design must be in reviewable status (in_review or revision_requested).
+    Valid post-review statuses: revision_requested, analyzing, supported,
+    rejected, inconclusive.
 
     Returns: dict with comment_id, design_id, status_after, message
     """
@@ -421,8 +426,9 @@ async def save_review_batch(
 ) -> dict:
     """Save a batch of review comments and transition the design status.
 
-    The design must be in 'in_review' status. Each comment can optionally
-    include target_section and target_content for inline anchoring.
+    The design must be in reviewable status (in_review or revision_requested).
+    Each comment can optionally include target_section and target_content
+    for inline anchoring.
 
     Valid status_after values: revision_requested, analyzing, supported, rejected, inconclusive.
 

--- a/tests/test_designs.py
+++ b/tests/test_designs.py
@@ -586,6 +586,38 @@ def test_create_design_without_methodology_is_none(
     assert design.methodology is None
 
 
+def test_create_design_without_methodology_logs_warning(
+    service: DesignService,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#81: create without methodology emits a warning log."""
+    with caplog.at_level(logging.WARNING, logger="insight_blueprint.core.designs"):
+        service.create_design(
+            title="Missing method",
+            hypothesis_statement="s",
+            hypothesis_background="b",
+        )
+    assert any("methodology" in r.message.lower() for r in caplog.records)
+
+
+def test_create_design_with_methodology_no_warning(
+    service: DesignService,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#81: create with methodology does NOT emit a warning."""
+    with caplog.at_level(logging.WARNING, logger="insight_blueprint.core.designs"):
+        service.create_design(
+            title="Has method",
+            hypothesis_statement="s",
+            hypothesis_background="b",
+            methodology={"method": "OLS", "reason": "standard"},
+        )
+    methodology_warnings = [
+        r for r in caplog.records if "methodology" in r.message.lower()
+    ]
+    assert len(methodology_warnings) == 0
+
+
 def test_update_design_with_methodology(
     service: DesignService,
 ) -> None:

--- a/tests/test_reviews.py
+++ b/tests/test_reviews.py
@@ -55,7 +55,7 @@ class TestTransitionStatus:
             ("supported", "in_review"),
             ("rejected", "in_review"),
             ("inconclusive", "in_review"),
-            ("revision_requested", "supported"),
+            ("analyzing", "supported"),
         ],
     )
     def test_invalid_transitions(
@@ -156,19 +156,55 @@ class TestSaveReviewComment:
         assert comment is not None
         assert comment.status_after == DesignStatus.inconclusive
 
-    def test_save_review_comment_on_non_in_review_raises_value_error(
+    def test_save_review_comment_on_revision_requested_succeeds(
+        self,
+        review_service: ReviewService,
+        design_service: DesignService,
+        active_design: AnalysisDesign,
+    ) -> None:
+        """#82: commenting on a revision_requested design succeeds."""
+        # First review: in_review -> revision_requested
+        review_service.save_review_comment(
+            active_design.id, "Needs more data", "revision_requested"
+        )
+        # Re-review directly from revision_requested (no manual transition)
+        comment = review_service.save_review_comment(
+            active_design.id, "Looks good now", "supported"
+        )
+        assert comment is not None
+        assert comment.status_after == DesignStatus.supported
+        reloaded = design_service.get_design(active_design.id)
+        assert reloaded is not None
+        assert reloaded.status == DesignStatus.supported
+
+    def test_save_review_comment_on_terminal_raises_value_error(
         self,
         review_service: ReviewService,
         design_service: DesignService,
     ) -> None:
-        """R2-AC6: commenting on a non-in_review design raises ValueError."""
+        """R2-AC6: commenting on a terminal design raises ValueError."""
         design = design_service.create_design(
             title="Terminal",
             hypothesis_statement="stmt",
             hypothesis_background="bg",
         )
         design_service.update_design(design.id, status=DesignStatus.supported)
-        with pytest.raises(ValueError, match="in_review"):
+        with pytest.raises(ValueError, match="reviewable"):
+            review_service.save_review_comment(design.id, "comment", "supported")
+
+    def test_save_review_comment_on_analyzing_raises_value_error(
+        self,
+        review_service: ReviewService,
+        design_service: DesignService,
+    ) -> None:
+        """#82 review: analyzing state is not reviewable."""
+        design = design_service.create_design(
+            title="Analyzing",
+            hypothesis_statement="stmt",
+            hypothesis_background="bg",
+        )
+        design_service.update_design(design.id, status=DesignStatus.analyzing)
+        with pytest.raises(ValueError, match="reviewable"):
             review_service.save_review_comment(design.id, "comment", "supported")
 
     def test_save_review_comment_invalid_status_value(
@@ -710,15 +746,59 @@ class TestSaveReviewBatch:
         assert result is not None
         assert result.comments[0].target_content == content
 
-    def test_save_batch_rejects_non_in_review(
+    def test_save_batch_on_revision_requested_succeeds(
+        self,
+        review_service: ReviewService,
+        design_service: DesignService,
+        active_design: AnalysisDesign,
+    ) -> None:
+        """#82: batch review on a revision_requested design succeeds."""
+        # First batch: in_review -> revision_requested
+        review_service.save_review_batch(
+            active_design.id,
+            "revision_requested",
+            [{"comment": "Needs revision"}],
+        )
+        # Re-review directly from revision_requested (no manual transition)
+        result = review_service.save_review_batch(
+            active_design.id,
+            "supported",
+            [{"comment": "Approved after revision"}],
+        )
+        assert result is not None
+        assert result.status_after == DesignStatus.supported
+        reloaded = design_service.get_design(active_design.id)
+        assert reloaded is not None
+        assert reloaded.status == DesignStatus.supported
+
+    def test_save_batch_rejects_terminal_design(
         self,
         review_service: ReviewService,
         non_pending_design: AnalysisDesign,
     ) -> None:
-        """AC: Non-in_review design raises ValueError."""
-        with pytest.raises(ValueError, match="in_review"):
+        """AC: Terminal design raises ValueError."""
+        with pytest.raises(ValueError, match="reviewable"):
             review_service.save_review_batch(
                 non_pending_design.id,
+                "supported",
+                [{"comment": "Should fail"}],
+            )
+
+    def test_save_batch_rejects_analyzing_design(
+        self,
+        review_service: ReviewService,
+        design_service: DesignService,
+    ) -> None:
+        """#82 review: analyzing state is not reviewable for batches."""
+        design = design_service.create_design(
+            title="Analyzing",
+            hypothesis_statement="stmt",
+            hypothesis_background="bg",
+        )
+        design_service.update_design(design.id, status=DesignStatus.analyzing)
+        with pytest.raises(ValueError, match="reviewable"):
+            review_service.save_review_batch(
+                design.id,
                 "supported",
                 [{"comment": "Should fail"}],
             )


### PR DESCRIPTION
## Summary

- **#82**: `revision_requested` 状態のデザインに対してレビューコメント/バッチを直接保存できるようにした。`_ensure_in_review` → `_ensure_reviewable` にガードを緩和し、`VALID_TRANSITIONS` も整合させた
- **#81**: `create_analysis_design` で `methodology` が null になる問題を三層で防止。Skill層(Required:Yes + 確認ステップ)、MCP層(docstring + パラメータ順序)、Service層(warning ログ)

## Changes

### #82: Review Workflow Guard Relaxation
| File | Change |
|------|--------|
| `core/reviews.py` | `REVIEWABLE_STATUSES` 追加、`_ensure_reviewable` にリネーム、`VALID_TRANSITIONS[revision_requested]` 拡張 |
| `server.py` | MCP ツール docstring 更新 |
| `test_reviews.py` | `revision_requested` 状態でのレビュー成功テスト、`analyzing` ブロックテスト追加 |

### #81: Methodology Null Triple-Layer Fix
| File | Change |
|------|--------|
| `SKILL.md` | methodology Required:Yes、Step 2.5 確認ステップ、テーブル更新 |
| `server.py` | methodology パラメータ位置変更 + docstring ガイダンス |
| `core/designs.py` | methodology=None 時の warning ログ |
| `test_designs.py` | warning ログの positive/negative テスト |

## Test plan
- [x] 816 tests passing (0 failures)
- [x] `revision_requested` → `save_review_comment` succeeds
- [x] `revision_requested` → `save_review_batch` succeeds
- [x] Terminal states (supported/rejected/inconclusive) still blocked
- [x] `analyzing` state blocked for review operations
- [x] methodology=None emits warning log
- [x] methodology provided: no warning
- [x] `ruff check` passes

Closes #82, closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)