### PR TITLE
chore: bump version to 0.4.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insight-blueprint",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Hypothesis-driven data analysis workflow and catalog MCP server",
   "author": { "name": "Eto Yama" },
   "repository": "https://github.com/etoyama/insight-blueprint",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "insight-blueprint"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server for data science analysis design management"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -793,7 +793,7 @@ wheels = [
 
 [[package]]
 name = "insight-blueprint"
-version = "0.4.0"
+version = "0.4.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump version to 0.4.3 after #92 merge

After merge, tag `v0.4.3` needs to be created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)