### PR TITLE
fix(#94): preserve existing keys in save_review_comment YAML write

### DIFF
--- a/src/insight_blueprint/core/reviews.py
+++ b/src/insight_blueprint/core/reviews.py
@@ -203,7 +203,7 @@ class ReviewService:
         existing = read_yaml(reviews_path)
         comments_list = existing.get("comments", [])
         comments_list.append(review_comment.model_dump(mode="json"))
-        write_yaml(reviews_path, {"comments": comments_list})
+        write_yaml(reviews_path, {**existing, "comments": comments_list})
 
         # Transition design status
         self._design_service.update_design(design_id, status=target_status)

--- a/src/insight_blueprint/core/reviews.py
+++ b/src/insight_blueprint/core/reviews.py
@@ -201,8 +201,10 @@ class ReviewService:
         # Persist comment
         reviews_path = self._designs_dir / f"{design_id}_reviews.yaml"
         existing = read_yaml(reviews_path)
-        comments_list = existing.get("comments", [])
-        comments_list.append(review_comment.model_dump(mode="json"))
+        comments_list = [
+            *existing.get("comments", []),
+            review_comment.model_dump(mode="json"),
+        ]
         write_yaml(reviews_path, {**existing, "comments": comments_list})
 
         # Transition design status
@@ -260,8 +262,7 @@ class ReviewService:
         # Persist batch to YAML (atomic write first)
         reviews_path = self._designs_dir / f"{design_id}_reviews.yaml"
         existing = read_yaml(reviews_path)
-        batches_list: list[dict] = existing.get("batches", [])
-        batches_list.append(batch.model_dump(mode="json"))
+        batches_list = [*existing.get("batches", []), batch.model_dump(mode="json")]
         write_yaml(reviews_path, {**existing, "batches": batches_list})
 
         # Transition design status (after YAML write succeeds)

--- a/tests/test_reviews.py
+++ b/tests/test_reviews.py
@@ -990,6 +990,41 @@ class TestSaveReviewBatch:
         batches = review_service.list_review_batches(active_design.id)
         assert len(batches) == 2
 
+    def test_save_batch_preserves_existing_comments(
+        self,
+        review_service: ReviewService,
+        design_service: DesignService,
+        active_design: AnalysisDesign,
+    ) -> None:
+        """Fix #94 symmetric: save_review_batch must not drop existing comments key."""
+        # First: add a single comment -> revision_requested
+        review_service.save_review_comment(
+            active_design.id, "Single comment", "revision_requested"
+        )
+        # Re-open for batch review
+        design_service.update_design(active_design.id, status=DesignStatus.in_review)
+
+        # Second: add a batch review — this must NOT drop comments
+        review_service.save_review_batch(
+            active_design.id,
+            "supported",
+            [
+                {
+                    "target_section": "hypothesis_statement",
+                    "target_content": "Test",
+                    "comment": "Batch comment",
+                }
+            ],
+        )
+
+        # Verify both keys survive
+        reviews_path = review_service._designs_dir / f"{active_design.id}_reviews.yaml"
+        data = read_yaml(reviews_path)
+        assert "comments" in data, "comments key was dropped by save_review_batch"
+        assert len(data["comments"]) == 1
+        assert "batches" in data
+        assert len(data["batches"]) == 1
+
     def test_save_batch_creates_new_file(
         self,
         review_service: ReviewService,

--- a/tests/test_reviews.py
+++ b/tests/test_reviews.py
@@ -218,6 +218,41 @@ class TestSaveReviewComment:
                 pending_design.id, "comment", "nonexistent_status"
             )
 
+    def test_save_review_comment_preserves_existing_batches(
+        self,
+        review_service: ReviewService,
+        design_service: DesignService,
+        pending_design: AnalysisDesign,
+    ) -> None:
+        """Fix #94: save_review_comment must not drop existing batches key."""
+        # First: add a batch review
+        review_service.save_review_batch(
+            pending_design.id,
+            "revision_requested",
+            [
+                {
+                    "target_section": "hypothesis_statement",
+                    "target_content": "Test",
+                    "comment": "Batch comment",
+                }
+            ],
+        )
+        # Re-open for next review cycle
+        design_service.update_design(pending_design.id, status=DesignStatus.in_review)
+
+        # Second: add a single comment — this must NOT drop batches
+        review_service.save_review_comment(
+            pending_design.id, "Single comment", "supported"
+        )
+
+        # Verify both keys survive in the reviews YAML
+        reviews_path = review_service._designs_dir / f"{pending_design.id}_reviews.yaml"
+        data = read_yaml(reviews_path)
+        assert "batches" in data, "batches key was dropped by save_review_comment"
+        assert len(data["batches"]) == 1
+        assert "comments" in data
+        assert len(data["comments"]) == 1
+
     def test_save_review_comment_missing_returns_none(
         self,
         review_service: ReviewService,


### PR DESCRIPTION
## Summary
- `save_review_comment` was overwriting the entire reviews YAML with only `{"comments": ...}`, dropping any existing `batches` key written by `save_review_batch`
- One-line fix: use `{**existing, "comments": comments_list}` to preserve all existing keys (same pattern as `save_review_batch`)
- Added regression test `test_save_review_comment_preserves_existing_batches`

## Horizontal Investigation
Audited all 14 `write_yaml` call sites in `src/`. Only `_reviews.yaml` files use a multi-key structure (comments + batches co-located). All other call sites use single-entity-per-file (Pydantic model dump), so this class of bug is isolated to `reviews.py:206`.

## Test plan
- [x] New test: batch review → single comment → verify both keys survive
- [x] All 136 existing review tests pass with no regressions

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)