### PR TITLE
chore: bump version to 0.4.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insight-blueprint",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Hypothesis-driven data analysis workflow and catalog MCP server",
   "author": { "name": "Eto Yama" },
   "repository": "https://github.com/etoyama/insight-blueprint",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "insight-blueprint"
-version = "0.4.3"
+version = "0.4.4"
 description = "MCP server for data science analysis design management"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` and `plugin.json` version from 0.4.3 to 0.4.4
- Release includes fix(#94): `save_review_comment` preserving existing YAML keys

## Post-merge
After merge, tag `v0.4.4` on main to trigger PyPI publish CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)