### PR TITLE
chore: add spec-workflow MCP server to project config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,10 @@
         "PYTHONUNBUFFERED": "1",
         "MCP_TIMEOUT": "10000"
       }
+    },
+    "spec-workflow": {
+      "command": "npx",
+      "args": ["-y", "@pimzino/spec-workflow-mcp@latest", "."]
     }
   }
 }


### PR DESCRIPTION
## Summary

- `.mcp.json` に `spec-workflow` MCP server を追加
- 既存 `insight-blueprint` entry は無変更（formatting ノイズなし、4 行追加のみ）

## Rationale

spec-workflow MCP は既に以下で参照されているが、`.mcp.json` に登録されておらず、各開発者が `claude mcp add` を手動実行しないと使えない状態だった:

- `.claude/settings.local.json` — `mcp__spec-workflow__*` の permissions
- `CLAUDE.md` — Spec-Driven Development Workflow の中核
- `.claude/docs/research/task5-claude-integration.md` — project scope での追加を推奨

Server 定義は `task5-claude-integration.md` の推奨に準拠（`npx -y @pimzino/spec-workflow-mcp@latest .`）。

## Test plan

- [x] `.mcp.json` JSON parse 可能
- [ ] Claude Code 再起動後 `spec-workflow` server が認識されること（merge 後ローカルで確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)