### PR TITLE
fix: sync uv.lock insight-blueprint version to 0.4.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -793,7 +793,7 @@ wheels = [
 
 [[package]]
 name = "insight-blueprint"
-version = "0.4.3"
+version = "0.4.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `uv.lock` 内の `insight-blueprint` self-reference を 0.4.3 → 0.4.4 に同期
- 変更は 1 行のみ、他の dependency lock は無変更

## Rationale

PR #96 で `pyproject.toml` を 0.4.4 にバンプしたが、`uv.lock` の regenerate が漏れていた。結果:

- `uv.lock` の `insight-blueprint` entry が 0.4.3 のまま
- `uv sync` や `uv lock --check` を走らせると version 不一致を警告する状態

本 PR は self-reference のみ最小 fix（`uv lock --upgrade-package insight-blueprint` 相当）。他の deps には触らない。

## Test plan

- [x] `uv sync` が警告なしに完了すること（ローカル確認済）
- [ ] CI の python job 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)