### PR TITLE
chore: ignore per-clone runtime stubs under .insight/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,9 +58,14 @@ summary.png
 *.log
 logs/
 
-# insight-blueprint runtime state (batch runs, approval tokens)
+# insight-blueprint runtime state (batch runs, approval tokens, per-clone stubs)
 .insight/runs/
 .insight/premortem/
+.insight/.sqlite/
+.insight/config.yaml
+.insight/rules/analysis_rules.yaml
+.insight/rules/review_rules.yaml
+.insight/rules/extracted_knowledge.yaml
 
 # Jupyter
 .ipynb_checkpoints/


### PR DESCRIPTION
## Summary

- `.insight/` 配下で runtime 自動生成される stub 5 種を `.gitignore` に追加
- 6 行追加 / 1 行修正（既存 comment の文言拡張）のみ

## Rationale

`.insight/` には **curated tracked 資産** と **per-clone runtime stub** が混在している:

| 種別 | 例 | 扱い |
|---|---|---|
| Curated (tracked 継続) | `methodology_vocab.yaml`, `package_allowlist.yaml`, `config.example.yaml` | 変更なし |
| Runtime stub (今回 ignore) | `.sqlite/catalog_fts.db`, `config.yaml` (init stub), `rules/analysis_rules.yaml`, `rules/review_rules.yaml`, `rules/extracted_knowledge.yaml` | 追加 |

生成ロジック:
- `.sqlite/` — `src/insight_blueprint/storage/project.py:58` が FTS5 DB 用 dir を作成、`storage/sqlite_store.py` が書き込む (binary)
- `config.yaml` — `project.py:50` が absent-only で `schema_version: 1` を作成
- `rules/*.yaml` — skills が runtime で空 rule set を生成

`.insight/rules/` を丸ごと ignore すると curated 資産も漏れるため、**ファイル単位で列挙**。

## Test plan

- [x] `git status` で untracked が消えることを確認（ローカル実測済）
- [x] 既存 tracked 資産 (`methodology_vocab.yaml` 等) が引き続き tracked であることを確認
- [ ] CI 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)