### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insight-blueprint",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Hypothesis-driven data analysis workflow and catalog MCP server",
   "author": { "name": "Eto Yama" },
   "repository": "https://github.com/etoyama/insight-blueprint",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-21
+
+### Added
+
+- New skill `/premortem` — pre-flight risk evaluation with approval token issuance (#117)
+- `spec-workflow` MCP server registered in `.mcp.json` (#118)
+
+### Changed
+
+- Batch analysis harness hardened for overnight stability (#117)
+  - Flat manifest status contract with `completed` state (was nested `execution.status`)
+  - 2-stage design hash verification for safe resume after crash
+  - Launcher-owned `finalize_run` for consistent lifecycle termination
+  - Hash mismatch detection in claude step + stub env toggles
+  - User-facing documentation for risk levels, `.insight/config.example.yaml`, crash recovery
+
+### Fixed
+
+- `uv.lock` self-reference version out of sync with `pyproject.toml` (#119)
+
+### Chore
+
+- Ignore per-clone runtime stubs under `.insight/` (#120)
+
+## [0.4.2] - [0.4.4]
+
+Version bumps and maintenance releases. See git history for details:
+`git log v0.4.1..v0.4.4 --oneline`.
+
 ## [0.4.1] - 2026-04-06
 
 ### Added
@@ -88,7 +117,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - YAML direct edit resilience (extra field preservation + corrupt file isolation)
 - SQLite FTS5 full-text search index
 
-[unreleased]: https://github.com/etoyama/insight-blueprint/compare/v0.4.0...HEAD
+[unreleased]: https://github.com/etoyama/insight-blueprint/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/etoyama/insight-blueprint/compare/v0.4.4...v0.5.0
+[0.4.1]: https://github.com/etoyama/insight-blueprint/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/etoyama/insight-blueprint/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/etoyama/insight-blueprint/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/etoyama/insight-blueprint/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ uv tool install insight-blueprint
 insight-blueprint --project /path/to/my-analysis
 ```
 
+### Updating
+
+When a new version is published, run the following from within Claude Code to pull the latest plugin (auto-update is off by default for third-party marketplaces):
+
+```bash
+/plugin marketplace update insight-blueprint-marketplace
+/plugin update insight-blueprint@insight-blueprint-marketplace
+```
+
+See [CHANGELOG.md](CHANGELOG.md) for release notes.
+
 ### Optional: Python Package
 
 For data-lineage tracking with `tracked_pipe` in your notebooks/scripts:
@@ -76,7 +87,7 @@ A browser-based dashboard (http://127.0.0.1:3000) with two tabs:
 
 ### Bundled Skills
 
-The plugin provides 8 analysis skills that are automatically available after installation:
+The plugin provides 9 analysis skills that are automatically available after installation:
 
 - `/analysis-framing` -- Explore available data and existing analyses to frame a hypothesis direction
 - `/analysis-design` -- Guided workflow for creating hypothesis documents
@@ -86,6 +97,7 @@ The plugin provides 8 analysis skills that are automatically available after ins
 - `/catalog-register` -- Step-by-step data source registration
 - `/data-lineage` -- Track data transformations and export lineage diagrams (Mermaid)
 - `/batch-analysis` -- Overnight batch execution of queued designs (headless notebooks, self-review, journal recording)
+- `/premortem` -- Pre-flight risk evaluation of queued designs with approval token issuance (gates `/batch-analysis`)
 
 Skills support both English and Japanese trigger phrases.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "insight-blueprint"
-version = "0.4.4"
+version = "0.5.0"
 description = "MCP server for data science analysis design management"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -793,7 +793,7 @@ wheels = [
 
 [[package]]
 name = "insight-blueprint"
-version = "0.4.4"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

v0.5.0 release PR — bundles #117 (batch harness + post-review fixes), #118, #119, #120.

Version bump + CHANGELOG + README refresh to ensure marketplace users can discover and apply the update.

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | `0.4.4` → `0.5.0` |
| `.claude-plugin/plugin.json` | `0.4.4` → `0.5.0` |
| `uv.lock` | self-reference sync to `0.5.0` |
| `CHANGELOG.md` | new `[0.5.0]` entry, gap-stub for `[0.4.2]-[0.4.4]` |
| `README.md` | skill count 8 → 9, `/premortem` added, new **Updating** section |

## Release notes (shipped in CHANGELOG)

### Added
- New skill `/premortem` — pre-flight risk evaluation with approval token issuance (#117)
- `spec-workflow` MCP server registered in `.mcp.json` (#118)

### Changed
- Batch analysis harness hardened for overnight stability (#117): flat manifest status contract, 2-stage hash verification, launcher-owned `finalize_run`, hash mismatch detection, user-facing risk-level docs and crash-recovery guide

### Fixed
- `uv.lock` self-reference out of sync with `pyproject.toml` (#119)

### Chore
- Ignore per-clone runtime stubs under `.insight/` (#120)

## After merge

1. `git tag v0.5.0 && git push origin v0.5.0` — triggers `publish.yml` (PyPI publish)
2. `gh release create v0.5.0 --notes-file <extracted CHANGELOG section>` — first GitHub Release

## Test plan

- [x] `scripts/check_tag_version.py --tag v0.5.0` passes locally
- [x] `uv sync` clean
- [ ] CI python / frontend / build-check green
- [ ] plugin-validate job passes (plugin.json integrity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)