### PR TITLE
fix(#123): remove $schema field and bump version to 0.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "insight-blueprint-marketplace",
   "owner": {
     "name": "etoyama"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insight-blueprint",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Hypothesis-driven data analysis workflow and catalog MCP server",
   "author": { "name": "Eto Yama" },
   "repository": "https://github.com/etoyama/insight-blueprint",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,8 @@ Version bumps and maintenance releases. See git history for details:
 - YAML direct edit resilience (extra field preservation + corrupt file isolation)
 - SQLite FTS5 full-text search index
 
-[unreleased]: https://github.com/etoyama/insight-blueprint/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/etoyama/insight-blueprint/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/etoyama/insight-blueprint/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/etoyama/insight-blueprint/compare/v0.4.4...v0.5.0
 [0.4.1]: https://github.com/etoyama/insight-blueprint/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/etoyama/insight-blueprint/compare/v0.3.0...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-04-21
+
+### Fixed
+
+- Remove `$schema` field from `.claude-plugin/marketplace.json` to restore plugin skill loading (#123)
+  - Claude Code's marketplace validator rejected `$schema` as an Unrecognized key,
+    causing the runtime to treat the plugin as disabled even when enabled in settings
+  - This blocked all insight-blueprint skills (`analysis-design`, `analysis-framing`,
+    `catalog-register`, `premortem`, etc.) from loading into the available skills list
+
 ## [0.5.0] - 2026-04-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "insight-blueprint"
-version = "0.5.0"
+version = "0.5.1"
 description = "MCP server for data science analysis design management"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -793,7 +793,7 @@ wheels = [
 
 [[package]]
 name = "insight-blueprint"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #123

## Summary

Claude Code の marketplace validator が `$schema` フィールドを Unrecognized key として reject し、plugin が settings 上 enabled でも runtime で disabled 扱いになる問題を修正する。併せて version 0.5.1 に bump し、autoUpdate 経由で既存 0.5.0 ユーザに fix を配布する。

**ローカル検証の制約**: Claude Code の plugin runtime キャッシュ層がローカル編集を反映せず（disable/enable 往復・両 cache 層の上書きいずれも runtime disabled を解消せず）、リリース前のローカル検証が困難と判明。`claude plugin validate` は両パスで通過しており fix の正しさは確認済みのため、merge → autoUpdate → 本番同等検証の方針をとる。

**Merge 後の検証手順**:

1. `claude plugin update insight-blueprint@insight-blueprint-marketplace` で cache を更新（autoUpdate が効いていれば自動）
2. Claude Code を再起動
3. `claude plugin list` で `insight-blueprint` が `Status: ✔ enabled` になることを確認
4. available skills list に `insight-blueprint:analysis-design` 等が出現することを確認

## Changes

- `.claude-plugin/marketplace.json`: `$schema` フィールドを削除（fix 本体）
- `.claude-plugin/plugin.json`: version 0.5.0 → 0.5.1
- `pyproject.toml`: version 0.5.0 → 0.5.1
- `uv.lock`: insight-blueprint の self-reference version 0.5.0 → 0.5.1
- `CHANGELOG.md`: `[0.5.1]` エントリ追加（Fixed セクション、#123 記載）+ 末尾比較リンク定義を 0.5.1 用に更新（他バージョンとの一貫性回復）

## Related Issues

Closes #123

## Checklist

- [ ] `poe all` passes (lint + typecheck + test)
- [ ] Tests added/updated for new functionality
- [ ] No hardcoded secrets or sensitive data
