### PR TITLE
fix(#147): add --verbose to claude -p stream-json invocations

### DIFF
--- a/skills/batch-analysis/launcher.sh
+++ b/skills/batch-analysis/launcher.sh
@@ -339,7 +339,7 @@ if [ -n "$RESUME_SESSION_ID" ]; then
     echo "Resuming session: $RESUME_SESSION_ID" >&2
     claude -p "$(cat "${CLAUDE_SKILL_DIR}/references/batch-prompt.md")" \
         --model sonnet \
-        --output-format stream-json \
+        --output-format stream-json --verbose \
         --include-hook-events \
         --fallback-model sonnet \
         --max-turns "${BATCH_MAX_TURNS}" \
@@ -351,7 +351,7 @@ if [ -n "$RESUME_SESSION_ID" ]; then
 else
     claude -p "$(cat "${CLAUDE_SKILL_DIR}/references/batch-prompt.md")" \
         --model sonnet \
-        --output-format stream-json \
+        --output-format stream-json --verbose \
         --include-hook-events \
         --fallback-model sonnet \
         --max-turns "${BATCH_MAX_TURNS}" \

--- a/tests/e2e/stub_claude.py
+++ b/tests/e2e/stub_claude.py
@@ -49,6 +49,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("-p", "--prompt", dest="prompt", nargs="?", default=None)
     p.add_argument("--approved-by", dest="approved_by", default=None)
     p.add_argument("--output-format", dest="output_format", default="text")
+    p.add_argument("--verbose", action="store_true")
     p.add_argument("--include-hook-events", action="store_true")
     p.add_argument("--fallback-model", default=None)
     p.add_argument("--max-turns", type=int, default=200)


### PR DESCRIPTION
## Summary

`skills/batch-analysis/launcher.sh` の `claude -p` 起動箇所 2 つで `--output-format stream-json` の直後に `--verbose` を追加し、上流 `claude` CLI 仕様変更（`--print` + `stream-json` に `--verbose` が必須化）による起動直後失敗を解消する。

### 修正内容

`skills/batch-analysis/launcher.sh` の 2 箇所（resume path: line 342, fresh run path: line 354）で `--output-format stream-json` の直後に `--verbose` を追加した。

### 原因

上流 `claude` CLI が `--print` + `--output-format stream-json` の組み合わせに対して `--verbose` を必須化する仕様変更を行ったため、`batch-analysis` の `launcher.sh` が起動直後に以下のエラーで終了していた:

```
Error: When using --print, --output-format=stream-json requires --verbose
```

### 検証

- 修正前: `--output-format stream-json --verbose` を含む行が 0 件、`--output-format stream-json` 行が 2 件、`bash -n` OK
- 修正後: `--output-format stream-json --verbose` を含む行が 2 件、`--verbose` 無しの stream-json 行が 0 件、`bash -n` OK
- 手元での再現テスト（premortem トークン取得 + 実 batch 実行）はコスト高のため省略
- diff は issue #147 本文の修正案と完全一致

## Changes

- `skills/batch-analysis/launcher.sh` (+2/-2)

## Related Issues

Closes #147

## Checklist

- [ ] `poe all` passes (lint + typecheck + test)
- [ ] Tests added/updated for new functionality
- [ ] No hardcoded secrets or sensitive data
