### PR TITLE
feat: add /rq-problematization skill (v0.6.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "insight-blueprint",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Hypothesis-driven data analysis workflow and catalog MCP server",
   "author": { "name": "Eto Yama" },
   "repository": "https://github.com/etoyama/insight-blueprint",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-16
+
+### Added
+
+- New skill `/rq-problematization` — generate impactful research questions via the Alvesson & Sandberg (2011) problematization framework: surface taken-for-granted assumptions across five types and challenge them with a devil's-advocate critic subagent (assumption-challenging over gap-spotting)
+  - Positioned upstream of `/analysis-framing`: rq-problematization (theory-driven RQ) → analysis-framing (data grounding) → analysis-design. Does not chain directly to analysis-design — framing is the data-grounding gate
+  - Re-generation path from `/analysis-reflection`: when a hypothesis is rejected/inconclusive, question the underlying assumption instead of only seeking a new angle
+  - Bundled `evals/evals.json` — the repository's first eval suite, focused on gap-spotting regression and citation-fabrication checks
+
 ## [0.5.1] - 2026-04-21
 
 ### Fixed
@@ -127,7 +136,8 @@ Version bumps and maintenance releases. See git history for details:
 - YAML direct edit resilience (extra field preservation + corrupt file isolation)
 - SQLite FTS5 full-text search index
 
-[unreleased]: https://github.com/etoyama/insight-blueprint/compare/v0.5.1...HEAD
+[unreleased]: https://github.com/etoyama/insight-blueprint/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/etoyama/insight-blueprint/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/etoyama/insight-blueprint/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/etoyama/insight-blueprint/compare/v0.4.4...v0.5.0
 [0.4.1]: https://github.com/etoyama/insight-blueprint/compare/v0.4.0...v0.4.1

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ A browser-based dashboard (http://127.0.0.1:3000) with two tabs:
 
 ### Bundled Skills
 
-The plugin provides 9 analysis skills that are automatically available after installation:
+The plugin provides 10 analysis skills that are automatically available after installation:
 
+- `/rq-problematization` -- Generate impactful research questions by problematizing the assumptions in prior research (upstream of framing)
 - `/analysis-framing` -- Explore available data and existing analyses to frame a hypothesis direction
 - `/analysis-design` -- Guided workflow for creating hypothesis documents
 - `/analysis-journal` -- Record reasoning steps during analysis (observations, evidence, decisions, questions)
@@ -106,6 +107,8 @@ Skills support both English and Japanese trigger phrases.
 Skills chain together to support the full hypothesis-driven analysis lifecycle:
 
 ```
+/rq-problematization (problematize assumptions → research questions)  ← optional upstream
+    ↓ (RQ Brief)
 /analysis-framing (explore data, frame direction)
     ↓
 /analysis-design (create hypothesis)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "insight-blueprint"
-version = "0.5.1"
+version = "0.6.0"
 description = "MCP server for data science analysis design management"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/skills/analysis-framing/SKILL.md
+++ b/skills/analysis-framing/SKILL.md
@@ -37,6 +37,10 @@ Accept the analysis theme from `$ARGUMENTS` or ask the user for one.
   - Ask the user to select or refine a direction before proceeding
   - Do NOT depend on development-partner for theme narrowing --- handle it independently
 - If forwarded from development-partner: accept the framing context from the conversation and build upon it
+- If an **RQ Brief** is present in the conversation (forwarded from `/rq-problematization`):
+  use its `テーマ` as the theme and its `検証の方向性` as the seed direction. The research
+  questions are theory-driven and not yet grounded — your job is to ground them in
+  available data. Carry the central assumption forward into the Direction Dialogue (Step 4).
 - If `.insight/` directory does not exist: inform the user that the project is not initialized and guide them to run `insight-blueprint init`. Stop the workflow here.
 
 ### Step 2: Domain Exploration (Agentic Search)
@@ -168,6 +172,7 @@ After outputting the Framing Brief, suggest:
 | From | To | When |
 |------|-----|------|
 | /development-partner* | → /analysis-framing | 分析テーマが出て、ドメイン接地が必要: "データと既存分析を探索するなら /analysis-framing" |
+| /rq-problematization | → /analysis-framing | RQ が出てデータ接地が必要（RQ Brief 付き）: "RQ をデータに接地して検証枠組みにするなら /analysis-framing" |
 | /analysis-design | → /analysis-framing | データ不足で仮説の方向を再検討: "データを探し直すなら /analysis-framing" |
 | /analysis-reflection | → /analysis-framing | 新仮説が必要だがデータ・方向の探索が先: "新しい角度を探すなら /analysis-framing" |
 | /catalog-register | → /analysis-framing | データ登録完了、フレーミングに戻る: "フレーミングに戻るなら /analysis-framing" |

--- a/skills/analysis-reflection/SKILL.md
+++ b/skills/analysis-reflection/SKILL.md
@@ -146,6 +146,7 @@ If user chooses to refine:
 | /analysis-reflection | → /analysis-journal | Need more evidence or branching |
 | /analysis-reflection | → /catalog-register | Conclusion worth registering as knowledge |
 | /analysis-reflection | → /analysis-framing | New hypothesis needed, explore data/direction first: "新しい角度を探すなら /analysis-framing" |
+| /analysis-reflection | → /rq-problematization | 仮説が棄却/不確定で、別角度でなく前提自体を問い直したい: "前提から問い直すなら /rq-problematization" |
 | /analysis-reflection | → /analysis-design | Derived hypothesis already clear: "派生仮説を作るなら /analysis-design" |
 
 ## Language Rules

--- a/skills/rq-problematization/SKILL.md
+++ b/skills/rq-problematization/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: rq-problematization
+version: "1.0.0"
+description: |
+  Generates impactful research questions using Alvesson & Sandberg's (2011)
+  problematization framework. Collects prior research, surfaces the assumptions a
+  literature takes for granted across five types, and dialectically challenges them
+  via a devil's-advocate subagent — moving beyond gap-spotting to assumption-challenging.
+  Triggers: "リサーチクエスチョンを考えたい", "研究テーマから問いを立てたい",
+  "問題化したい", "先行研究の前提を疑いたい", "インパクトのある研究の切り口がほしい",
+  "research question を作りたい", "problematization".
+disable-model-invocation: true
+argument-hint: "[theme]"
+---
+
+# /rq-problematization — Research Question Problematization
+
+Generates impactful (interesting and influential) research questions from a research
+theme, grounded in Alvesson & Sandberg (2011) "Generating Research Questions Through
+Problematization" (*Academy of Management Review*, 36(2), 247-271) and the sister paper
+Sandberg & Alvesson (2011) "Ways of constructing research questions: gap-spotting or
+problematization?" (*Organization*, 18(1), 23-44).
+
+Read `references/alvesson-framework.md` first to load the exact definitions of the
+framework before running the workflow.
+
+## When to Use
+- Have a research theme and want to generate impactful, novel research questions
+- Want to question the taken-for-granted assumptions underlying prior research
+- Need an angle that goes beyond incremental gap-filling
+
+## When NOT to Use
+- Want to explore available data and frame a verifiable direction → `/analysis-framing`
+- Hypothesis is already clear and only needs structuring into a design → `/analysis-design`
+- Recording reasoning during an ongoing analysis → `/analysis-journal`
+
+## Core Principle: problematization, not gap-spotting
+
+This is the heart of the skill and the easiest point to fail. Most RQ generation
+collapses into **gap-spotting** — looking for "what is missing in the literature."
+That is safe but bland and rarely produces influential theory. Alvesson argues that
+theory becomes "interesting" only when we **identify the assumptions that existing
+research takes for granted, then question and overturn them** (cf. Davis 1971,
+"That's Interesting!").
+
+Therefore, at every stage of the workflow, ask:
+- "Is this merely pointing at an *under-researched area*?" (= gap-spotting)
+- "Is this shaking an assumption the literature *takes for granted*?" (= problematization)
+If it is not the latter, redo it.
+
+## Workflow Overview
+
+A flow mapped onto Alvesson's six-step logic. Copy the following checklist into your
+response at the start and track progress (a pattern recommended for complex workflows):
+
+```
+Problematization progress:
+- [ ] 1. Theme received
+- [ ] 2. Literature domain identified & prior research collected (with verification status)
+- [ ] 3. Existing theory summarized
+- [ ] 4. Assumptions extracted (5 types)
+- [ ] 5. Dialectical dialogue with critic (gap-rephrasings removed)
+- [ ] 6. Assumptions evaluated (Davis typology + why now)
+- [ ] 7. Alternative assumptions developed & RQs generated
+- [ ] 8. Audience relationship considered
+- [ ] 9. Markdown output produced
+```
+
+Run Steps 2–8 internally. Insert one optional human checkpoint at **Step 4 (extracted
+assumptions)**. At the very start, ask once: "前提リストを一度確認しますか？それとも
+最後まで自動で進めますか？"
+
+---
+
+## Step Details
+
+### Step 1: Receive Theme
+
+Accept the research theme from `$ARGUMENTS` or ask the user for one.
+- If `$ARGUMENTS` is provided, use it as the theme.
+- If the theme is too broad (e.g., "leadership"), confirm a single focus first.
+- If forwarded from `/development-partner` or carrying an upstream context, build on it.
+
+### Step 2: Identify Literature Domain & Collect Prior Research
+
+**Citation accuracy is the top priority. Never invent papers or authors.** This is a
+tool for researchers; fabricated citations are fatal.
+
+- Use `WebSearch` to find major prior research, review articles, and key theorists.
+  Prioritize Google Scholar / Semantic Scholar / journal pages.
+- Adopt only citations whose author, year, title, venue, **volume, and page range** you
+  could **verify through search**.
+- If full text is paywalled, work from the abstract, reference lists, or secondary
+  sources (and state that the full text was not read).
+- In the output, tag every citation with a verification status:
+  `[検索で確認済]` / `[要旨のみ確認]` / `[未確認・要検証]`.
+  - `[検索で確認済]` means the author name(s), year, exact title, venue, and volume/pages
+    were all confirmed via a search result pointing to the publisher's or an indexing
+    service's page. **If the author names do not match the actual paper, it is NOT
+    verified — do not apply this tag.**
+- For any claim you cannot verify, attach `[未確認・要検証]` — never fill the gap with
+  fabrication.
+
+The goal is to grasp the **home position** (dominant view) and the **main schools** of
+the domain.
+
+### Step 3: Summarize Existing Theory
+
+Concisely describe "what the existing theory looks like": the dominant theoretical
+position, the main schools, and the shared view in the field.
+
+### Step 4: Extract Assumptions (the heart of the skill)
+
+For each of the five types, explicitly articulate what the existing literature
+**takes for granted**. Use the definitions and prompting questions in
+`references/alvesson-framework.md`.
+
+| Type | What to question | Difficulty | Potential impact |
+|------|------------------|------------|------------------|
+| in-house | In-house assumptions of a specific school | Low | Low–Mid |
+| root metaphor | The underlying metaphor/image of the field | Mid | Mid–High |
+| paradigm | Ontological / epistemological / methodological assumptions | High | High |
+| ideology | Political / moral / gender-related assumptions | High | High |
+| field | Assumptions shared across competing schools | Highest | Highest |
+
+Difficulty and potential impact trade off. Where possible, draw assumptions from
+multiple types so the later evaluation can choose an ambition level.
+
+**Critical:** what you surface here is not "what the literature does not say" but
+"what the literature assumes without saying." The former is a gap; the latter is an
+assumption. If you conflate them, re-extract.
+
+### Step 5: Dialectical Dialogue with a Critic Agent
+
+Problematization is a dialectical process. Test the quality of the extracted
+assumptions by **spawning a separate critic (devil's advocate) agent**. Launch it with
+the `Agent` tool (subagent_type: `general-purpose`) and ask it to:
+
+> You are a critical reviewer. Scrutinize the following list of "extracted assumptions"
+> and evaluate each item strictly:
+> 1. Is this genuinely an assumption the existing research *takes for granted*, or is it
+>    merely a rephrasing of an under-researched area (a gap)?
+> 2. Do the major researchers/schools really believe this assumption? Are there
+>    counter-examples (research that already questions it)?
+> 3. If overturned, what would change theoretically? Is the impact real or trivial?
+> 4. Is there a deeper/more fundamental assumption hidden behind it?
+> Classify each assumption as "true assumption / gap-rephrasing / already challenged"
+> and return improvement suggestions.
+
+Use the critic's feedback to remove gap-rephrasings and refine the assumptions. One or
+two rounds if needed. This realizes dialectical depth without human intervention.
+
+**If subagents are unavailable:** when the `Agent` tool cannot be used, switch roles
+explicitly and become the "critic" yourself, refuting each extracted assumption once
+using the critique points above (making the role switch explicit improves quality). If
+even that is impractical, present the pre-refinement assumption list to the human and
+ask them to select/reject.
+
+(In human-checkpoint mode, present the refined assumption list here and ask the user to
+select/modify.)
+
+### Step 6: Evaluate Assumptions
+
+Evaluate "is it worth challenging?" on two axes:
+
+**(a) Impact if overturned** — label with the Davis (1971) interestingness typology
+(see `references/davis-interestingness.md`). E.g., "what seems single is actually
+plural," "what seems independent is actually interdependent," "what is deemed good is
+actually bad." Naming the type clarifies the *kind* of impact.
+
+**(b) Feasibility of overturning** — the reason this assumption *can be challenged now*:
+new empirical evidence/data, technological innovation, social/institutional change, or
+new theory from an adjacent field. The more concretely you can state "why now," the
+stronger and more timely the RQ.
+
+Drop assumptions weak on both axes; keep the strong ones.
+
+### Step 7: Develop Alternative Assumptions & Generate RQs
+
+For each chosen assumption, construct an **alternative assumption ground** and write the
+RQ it generates.
+- The RQ must directly reflect the assumption shift (not a gap-filling question).
+- Attach a **verification plan** to each RQ: research design, data, method, and
+  falsifiable hypotheses.
+
+### Step 8: Consider the Audience
+
+Alvesson's step 5. Skipping it yields "interesting but nobody cares" problematization.
+- Which audience (school/community) holds this assumption?
+- What message would persuade them and make it "interesting"?
+- What pushback is expected, and how to mitigate it.
+
+### Step 9: Produce Output
+
+Generate a Japanese markdown file following the structure in
+`references/output-template.md`. **Save the file to the working directory and present
+its path to the user** (do not rely on any external presentation mechanism).
+
+Then output a concise **RQ Brief** in the conversation so the next skill
+(`/analysis-framing`) can pick it up and ground it in data:
+
+````markdown
+## RQ Brief
+
+### テーマ
+{theme_one_liner}
+
+### 疑う中心的前提（類型）
+{central assumption being challenged} ({type})
+
+### リサーチクエスチョン
+- {RQ 1}
+- {RQ 2}
+
+### 検証の方向性（要データ接地）
+- {what data / method could test these — to be grounded by analysis-framing}
+````
+
+After the RQ Brief, suggest:
+"データに接地して検証可能な枠組みにするなら `/analysis-framing`"
+
+---
+
+## Notes Throughout
+
+- **Self-check for gap-spotting regression** at every step. This is the biggest quality
+  factor.
+- **Cite only what you verified.** Always show the verification status. Fabrication is
+  forbidden.
+- The generated document is in **Japanese**; key concepts may carry the English
+  original in parentheses (useful when writing the paper).
+- In assumption extraction, prefer drawing candidates across **multiple types** to
+  preserve a choice of ambition level.
+- **Do not skip the critic agent.** Dialectical verification is what underpins quality.
+
+## Chaining
+
+| From | To | When |
+|------|-----|------|
+| /development-partner* | → /rq-problematization | 研究テーマがあり先行研究の前提を問い直したい: "前提を疑うなら /rq-problematization" |
+| /analysis-reflection | → /rq-problematization | 仮説が棄却/不確定で前提から問い直したい: "前提から問い直すなら /rq-problematization" |
+| /rq-problematization | → /analysis-framing | RQ が出てデータ接地が必要: "データに接地して検証枠組みにするなら /analysis-framing" |
+
+\* = 外部スキル（development-deck）。存在時のみ表示する。存在しない場合この行は Chaining セクションに含めない。
+
+Note: `/rq-problematization` does not chain directly to `/analysis-design`. The RQ must
+first be grounded in available data by `/analysis-framing`, which is the data-grounding
+gate before a hypothesis is structured.
+
+## Language Rules
+- Follow project CLAUDE.md language settings. Default to Japanese if no setting.
+- Code, IDs, tool names, and YAML fields always stay in English.
+- The generated research-question document is written in Japanese (key concepts may
+  include the English original in parentheses).

--- a/skills/rq-problematization/evals/evals.json
+++ b/skills/rq-problematization/evals/evals.json
@@ -1,0 +1,45 @@
+{
+  "skill_name": "rq-problematization",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "組織改善と業績の連動性について、インパクトのあるリサーチクエスチョンを考えたい。",
+      "expected_output": "A Japanese markdown document that problematizes the assumed link between organizational improvement and performance: it surfaces a taken-for-granted assumption (e.g., the assumed causal direction improvement→performance), challenges it via a critic, and produces RQs with verification plans plus an RQ Brief for /analysis-framing.",
+      "expectations": [
+        "The challenged target is an assumption the literature takes for granted (e.g., 'improvement causes performance is assumed', or a reverse-causation / co-relation framing), NOT a statement that some area is 'under-researched' (problematization, not gap-spotting)",
+        "Every cited work carries a verification-status tag ([検索で確認済] / [要旨のみ確認] / [未確認・要検証]); no reference appears without a status, and no fabricated author/year/title/venue is presented as verified",
+        "The challenge summary table contains all five columns: challenged assumption (with type) / impact-if-overturned labeled with a Davis typology / why-now feasibility / research question / verification plan",
+        "Candidate assumptions are drawn from more than one of the five types (in-house / root metaphor / paradigm / ideology / field)",
+        "The audience-persuasion step (Alvesson step 5: who holds the assumption, how to persuade, expected pushback) is present",
+        "A devil's-advocate critic subagent was launched (Agent tool) and the assumptions were refined as a result (gap-rephrasings removed)",
+        "An RQ Brief is emitted and the skill suggests /analysis-framing (not /analysis-design) as the next step"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "リモートワークと組織コミットメントの関係で問題化したい。先行研究の前提を疑いたい。",
+      "expected_output": "A Japanese markdown document that challenges an assumption underlying remote-work / organizational-commitment research, leveraging recent contextual change (post-pandemic normalization) as the 'why now', with verification-tagged citations and an RQ Brief.",
+      "expectations": [
+        "The challenged target is a taken-for-granted assumption (e.g., physical co-presence is assumed necessary for commitment), NOT a 'not yet studied' gap (problematization, not gap-spotting)",
+        "Every cited work carries a verification-status tag and no fabricated citation is presented as verified",
+        "The why-now column gives a concrete reason the assumption is challengeable now (e.g., post-pandemic remote-work normalization, new longitudinal data), not a vague 'it is important'",
+        "The challenge summary table contains all five columns including a Davis-typed impact label",
+        "A devil's-advocate critic subagent was launched and assumptions were refined",
+        "An RQ Brief is emitted and /analysis-framing is suggested as the next step"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "心理的安全性とチームパフォーマンスについて、研究テーマから問いを立てたい。",
+      "expected_output": "A Japanese markdown document that problematizes the popular psychological-safety / team-performance construct, questioning an assumption that has hardened due to the concept's popularity, with verification-tagged citations and an RQ Brief.",
+      "expectations": [
+        "The challenged target is an assumption the literature takes for granted (e.g., psychological safety is assumed uniformly beneficial / its function is assumed positive), NOT an 'under-researched area' framing (problematization, not gap-spotting)",
+        "Every cited work carries a verification-status tag and no fabricated citation is presented as verified",
+        "At least one challenge uses a Davis typology of Function or Evaluation (what is deemed good is actually harmful in some condition), reflecting the over-popularized nature of the construct",
+        "The challenge summary table contains all five columns",
+        "A devil's-advocate critic subagent was launched and assumptions were refined",
+        "An RQ Brief is emitted and /analysis-framing is suggested as the next step"
+      ]
+    }
+  ]
+}

--- a/skills/rq-problematization/references/alvesson-framework.md
+++ b/skills/rq-problematization/references/alvesson-framework.md
@@ -1,0 +1,47 @@
+# Alvesson & Sandberg Problematization Framework (Reference)
+
+Sources:
+- Alvesson, M., & Sandberg, J. (2011). Generating Research Questions Through Problematization. *Academy of Management Review*, 36(2), 247-271.
+- Sandberg, J., & Alvesson, M. (2011). Ways of constructing research questions: gap-spotting or problematization? *Organization*, 18(1), 23-44.
+
+## Central Argument
+
+A theory becomes "interesting and influential" when it **meaningfully challenges assumptions taken for granted** in its field. Yet the dominant approach to constructing research questions remains "gap-spotting" -- finding or fabricating gaps in the existing literature. Alvesson proposes "problematization" as a methodology to move beyond this.
+
+### Gap-Spotting vs. Problematization
+
+| | Gap-spotting | Problematization |
+|---|---|---|
+| Target | "Gaps" or "blanks" in the literature | "Assumptions" on which the literature rests |
+| Stance | Accepts the existing framework and fills it in | Questions the existing framework itself |
+| Outcome | Tends to be safe, incremental, and unremarkable | Riskier, but can produce influential theory |
+| Typical question | "X has not yet been studied" | "Is X really Y? Or is that just what everyone assumes?" |
+
+Gap-spotting has three sub-types (confusion gap, neglect gap, application gap), none of which challenge underlying assumptions. The decisive criterion: **A gap merely states that "something is missing"; by itself it does not constitute a research "problem."** Problematization requires articulating "why that assumption is problematic, and for whom."
+
+## Five Types of Assumptions Subject to Problematization
+
+| Type | Definition | Example challenge question |
+|---|---|---|
+| **In-house** | Assumptions that exist within a particular school of thought and are shared by its adherents. | "What does this school take as self-evident? Does that proposition actually hold?" |
+| **Root metaphor** | The general image or metaphor underlying existing literature about the research topic. | "What metaphor does this field use for its subject (machine / organism / culture / polity / etc.)? What would we see through a different metaphor?" |
+| **Paradigm** | Ontological, epistemological, and methodological assumptions underlying existing literature. | "What is taken for granted about how the world is constituted (ontology), what counts as knowledge (epistemology), and how inquiry should proceed (methodology)?" |
+| **Ideology** | Political, moral, or gender-related assumptions underlying existing literature. | "Which values, interests, or norms are tacitly treated as correct? Whose perspective is centered, and whose is marginalized?" |
+| **Field** | Assumptions shared *across* different theoretical schools regarding a particular research topic. | "What assumption remains unquestioned even by schools that otherwise disagree?" |
+
+**Difficulty-Impact Trade-off:** In ascending order of difficulty (and impact upon success): in-house < root metaphor < paradigm ~ ideology < field. Overturning a field-level assumption yields the greatest influence but is also the hardest to pull off.
+
+**The Most Important Distinction:** What we identify here is not "what the literature has not said" (= gap) but "what the literature says without saying -- what it takes for granted" (= assumption).
+
+## Six-Step Procedure for Identifying and Challenging Assumptions (Principles)
+
+1. **Identify the literature domain** -- What are the major works and key texts in this domain?
+2. **Identify and articulate existing assumptions** -- What are the main assumptions in the identified domain?
+3. **Evaluate existing assumptions** -- Are the identified assumptions worth challenging?
+4. **Develop an alternative assumption ground** -- What alternative assumptions can be developed?
+5. **Relate the alternative assumptions to the audience** -- Can we craft a message that sufficiently persuades the primary audience that supports the challenged assumption?
+6. **Evaluate the alternative assumption ground** -- Can the alternative assumptions generate theory that the target audience will find "interesting"?
+
+## Dialectical and Iterative Nature
+
+Problematization is not a one-shot exercise. Research questions are refined through **dialectical re-examination** -- moving back and forth between one's own theoretical home position and the target literature being challenged. In this skill, this iteration is implemented through dialogue with the critic agent.

--- a/skills/rq-problematization/references/davis-interestingness.md
+++ b/skills/rq-problematization/references/davis-interestingness.md
@@ -1,0 +1,35 @@
+# Davis Interestingness Typology (Reference)
+
+Source: Davis, M. S. (1971). That's Interesting! Towards a Phenomenology of Sociology and a Sociology of Phenomenology. *Philosophy of the Social Sciences*, 1(2), 309-344.
+
+## Central Thesis
+
+A theory is perceived as "interesting" when it **negates an assumption that the audience takes for granted**. A claim that is "true but obvious" is not interesting; nor is one that "overturns common sense but is false." What is interesting is the structure: **"what was thought to be self-evident turns out not to be so."** This provides the theoretical foundation for Alvesson's problematization.
+
+Conversely, a claim that does not overturn an assumption (i.e., a conclusion from gap-filling) is "non-interesting" or merely confirms the obvious.
+
+## Typology for Labeling Impact
+
+When a taken-for-granted assumption is overturned, we label the *type* of interestingness it produces. Types for single phenomena (main ones):
+
+| Label | Structure: old assumption -> new claim | Example |
+|---|---|---|
+| **Organization** | What seems disordered -> actually has order / What seems ordered -> actually disordered | Seemingly disparate practices actually follow a coherent logic |
+| **Composition** | Separate elements -> actually identical / What seems unitary -> actually plural | "Organizational culture" is not monolithic but a competition among subcultures |
+| **Abstraction** | Individual property -> actually a collective property (or vice versa) | What was attributed to individual ability -> actually a product of relationships and context |
+| **Generalization** | What seems local -> actually universal / What seems universal -> actually local | Management principles thought to be universal -> actually culture-specific |
+| **Stabilization** | What seems stable -> actually changing (or vice versa) | Preferences thought to be fixed -> actually fluctuate with context |
+| **Function** | What is thought effective -> actually counterproductive / What is thought ineffective -> actually effective | A performance-improvement measure -> actually undermines performance |
+| **Evaluation** | What is thought good -> actually bad (or vice versa) | A "desirable" state turns out to be harmful |
+| **Co-relation** | What seems independent -> actually correlated / What seems correlated -> actually unrelated or spurious | Two variables thought to be related -> actually a spurious correlation |
+| **Causation** | What is thought to be the cause -> actually the effect (or vice versa) / What seems causal -> actually unrelated | A was thought to cause B, but actually B causes A |
+
+Types concerning relationships among multiple phenomena (reversal of correlation, causation, etc.) follow the same logic.
+
+## How to Use
+
+In Step 6, for each "challenge to an assumption," select one (or more) label from the table above and record it in the "Impact when overturned" column of the output. This ensures that impact is expressed not merely as "it is novel" but in concrete terms: "which piece of conventional wisdom is subverted, and how."
+
+## Caveat: Excessive Subversion Invites Rejection
+
+Davis notes that overturning too many assumptions (simultaneously negating multiple fundamental premises) crosses the line from "interesting" to "absurd" and triggers rejection. Challenging **one central assumption** is the most effective strategy. This aligns with Alvesson's "persuading the audience" (Step 5).

--- a/skills/rq-problematization/references/output-template.md
+++ b/skills/rq-problematization/references/output-template.md
@@ -1,0 +1,60 @@
+# Output Template (Reference)
+
+The final output is a Japanese markdown file following this structure. `{ }` marks fields to be filled in.
+
+---
+
+```markdown
+# 問題化によるリサーチクエスチョン案：{テーマ}
+
+## 0. 概要
+{このテーマでどんな前提を疑い、どんなRQに至ったかの2〜3行サマリ}
+
+## 1. 文献領域と主要先行研究
+{この領域の主要文献・カギとなる文献。各引用に検証ステータスを付す}
+
+- {著者(年)『タイトル』掲載先} — {一文要約} `[検索で確認済 / 要旨のみ確認 / 未確認・要検証]`
+- ...
+
+## 2. 既存理論はどのようなものか
+{支配的な理論的立場・主要学派・共有されている見方を簡潔に記述}
+
+## 3. 既存理論の前提は何か
+{5類型ごとに、文献が当然視している前提を列挙。該当しない類型は省略可}
+
+- **学派内(in-house)**：{前提}
+- **ルートメタファー(root metaphor)**：{前提}
+- **パラダイム(paradigm)**：{前提}
+- **イデオロギー(ideology)**：{前提}
+- **学術界(field)**：{前提}
+
+（批判者エージェントによる検証で、gapの言い換えだった項目は除外済み。検証の要点：{一言}）
+
+## 4. 前提への挑戦案まとめ
+
+| # | 挑戦する前提（類型） | 覆したときのインパクト（Davis類型） | 覆す可能性（なぜ今か） | リサーチクエスチョン | RQの検証案 |
+|---|---|---|---|---|---|
+| 1 | {前提}（{類型}） | {ラベル}：{何がどう裏切られるか} | {新証拠/技術/文脈変化など} | {RQ} | {研究デザイン・データ・手法} |
+| 2 | ... | ... | ... | ... | ... |
+| 3 | ... | ... | ... | ... | ... |
+
+## 5. 読者層への説得（手順5）
+{各挑戦案について、誰がその前提を支持しているか／どう説得し面白いと思わせるか／予想される反発と緩和策}
+
+## 6. 推奨
+{インパクト×実現可能性のバランスから、最も有望なRQを1〜2件推す。理由も}
+
+## 参考文献
+{検証ステータス付きの一覧}
+```
+
+---
+
+## Notes on Writing the Table
+
+- "Assumption challenged" column: Re-confirm that it is an assumption, not a gap ("X is taken for granted" rather than "X has not been studied").
+- "Impact when overturned" column: Always prepend a Davis typology label (Organization / Function / Evaluation / Causation, etc.) before the description.
+- "Possibility of overturning" column: State concretely "why this assumption can be challenged now." Vague claims like "because it is important" are not acceptable.
+- "RQ" column: Frame it so that it directly questions the reversal of the assumption. Prefer explanatory/mechanistic questions over yes/no questions.
+- "RQ verification plan" column: Provide a concrete, falsifiable design. Specify data sources, methods, and expected hypotheses.
+- Aim for 2-4 rows. Mixing challenges of different ambition levels (i.e., different assumption types) makes selection easier.

--- a/uv.lock
+++ b/uv.lock
@@ -793,7 +793,7 @@ wheels = [
 
 [[package]]
 name = "insight-blueprint"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Alvesson & Sandberg (2011) の問題化(problematization)フレームワークによるリサーチクエスチョン生成スキル `/rq-problematization` を追加し、0.5.1 → 0.6.0 に上げる。gap-spotting（未研究領域の指摘）ではなく既存研究が当然視する前提への挑戦を行う。批判者(devil's advocate)サブエージェントを Task/Agent tool で実装した点が Claude Code 向けに作る最大の動機。

## Changes

- **New skill** `skills/rq-problematization/` — SKILL.md + references/3ファイル + `evals/evals.json`
- **Workflow positioning**: rq-problematization（理論駆動でRQ生成）→ `/analysis-framing`（データ接地）→ `/analysis-design`。design へは直接繋がず、framing がデータ接地の関門
- **Chain entry points** added in `skills/analysis-framing/SKILL.md`（RQ Brief 検出 + Chaining 行）と `skills/analysis-reflection/SKILL.md`（棄却/不確定 → 前提から再生成）
- **`evals/evals.json`**: リポジトリ初の eval suite（gap-spotting 退化・引用捏造チェックの2軸）
- **Version bump** 0.5.1 → 0.6.0（`pyproject.toml`, `.claude-plugin/plugin.json`, `uv.lock`）+ `CHANGELOG.md`

### Eval 実測（1ケース: 組織改善と業績の連動性）

with-skill **6/7 pass** vs baseline **0/7**。両軸で baseline を明確に上回った:
- **gap-spotting 退化防止**: assumption-challenge 型 100%(3/3) vs baseline 50%(3/6、半分が「未研究」型に退化)
- **引用捏造防止**: 捏造ゼロ・全件に検証ステータスタグ vs baseline は著者名が実在論文と不一致の文献を「確認済」と誤タグ

## Related Issues

<!-- none -->

## Checklist

- [x] `poe all` passes (lint + typecheck + test)
- [ ] Tests added/updated for new functionality — N/A: スキルは Markdown 定義。機能検証は `evals/evals.json`（with-skill 6/7 vs baseline 0/7）で実施
- [x] No hardcoded secrets or sensitive data

> 検証メモ: `ruff check` / `ruff format --check` / `pytest`（1021 passed, 1 skipped）は green。`ty check` の 1 diagnostic は `src/` の既存コード（不要な `type: ignore`）で、本 PR の diff 外。